### PR TITLE
fix: wait for dhts to have peers before starting the tests

### DIFF
--- a/testing/dht_network.go
+++ b/testing/dht_network.go
@@ -78,10 +78,15 @@ func WaitForPeerTableToUpdate(ctx context.Context, dhts []*p2p.QgbDHT, timeout t
 		case <-withTimeout.Done():
 			return ErrTimeout
 		case <-ticker.C:
-			for _, dht := range dhts {
-				if len(dht.RoutingTable().ListPeers()) == 0 {
-					continue
+			allPeersConnected := func() bool {
+				for _, dht := range dhts {
+					if len(dht.RoutingTable().ListPeers()) == 0 {
+						return false
+					}
 				}
+				return true
+			}
+			if allPeersConnected() {
 				return nil
 			}
 		}

--- a/testing/dht_network.go
+++ b/testing/dht_network.go
@@ -2,13 +2,14 @@ package testing
 
 import (
 	"context"
+	"time"
+
 	"github.com/celestiaorg/orchestrator-relayer/p2p"
 	ds "github.com/ipfs/go-datastore"
 	dssync "github.com/ipfs/go-datastore/sync"
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/host"
 	"github.com/libp2p/go-libp2p/core/peer"
-	"time"
 )
 
 // TestDHTNetwork is a test DHT network that can be used for tests.

--- a/testing/errors.go
+++ b/testing/errors.go
@@ -1,0 +1,5 @@
+package testing
+
+import "errors"
+
+var ErrTimeout = errors.New("timeout")


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

To avoid tests flakiness, we should wait for the DHTs to have their peers list populated before starting the tests.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
