### PR TITLE
chore: remove Msg prefix from confirms methods

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -329,7 +329,7 @@ func (orch Orchestrator) ProcessValsetEvent(ctx context.Context, valset celestia
 	}
 
 	// create and send the valset hash
-	msg := types.NewMsgValsetConfirm(
+	msg := types.NewValsetConfirm(
 		orch.OrchEVMAddress,
 		ethcmn.Bytes2Hex(signature),
 	)
@@ -359,7 +359,7 @@ func (orch Orchestrator) ProcessDataCommitmentEvent(
 		return err
 	}
 
-	msg := types.NewMsgDataCommitmentConfirm(commitment.String(), ethcmn.Bytes2Hex(dcSig), orch.OrchEVMAddress)
+	msg := types.NewDataCommitmentConfirm(commitment.String(), ethcmn.Bytes2Hex(dcSig), orch.OrchEVMAddress)
 	hash, err := orch.Broadcaster.BroadcastConfirm(ctx, msg)
 	if err != nil {
 		return err

--- a/p2p/dht_test.go
+++ b/p2p/dht_test.go
@@ -135,5 +135,5 @@ func TestNetworkGetNonExistentValsetConfirm(t *testing.T) {
 	// try to get the non-existent ValsetConfirm
 	actualConfirm, err := network.DHTs[8].GetValsetConfirm(context.Background(), testKey)
 	assert.Error(t, err)
-	assert.True(t, types.IsEmptyMsgValsetConfirm(actualConfirm))
+	assert.True(t, types.IsEmptyValsetConfirm(actualConfirm))
 }

--- a/types/data_commitment_confirm.go
+++ b/types/data_commitment_confirm.go
@@ -10,8 +10,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 )
 
-var _ AttestationConfirm = &DataCommitmentConfirm{}
-
 // DataCommitmentConfirm describes a data commitment for a set of blocks.
 type DataCommitmentConfirm struct {
 	// Signature over the commitment, the range of blocks, the validator address
@@ -25,8 +23,8 @@ type DataCommitmentConfirm struct {
 	Commitment string
 }
 
-// NewMsgDataCommitmentConfirm creates a new NewMsgDataCommitmentConfirm.
-func NewMsgDataCommitmentConfirm(
+// NewDataCommitmentConfirm creates a new NewDataCommitmentConfirm.
+func NewDataCommitmentConfirm(
 	commitment string,
 	signature string,
 	ethAddress ethcmn.Address,

--- a/types/valset_confirm.go
+++ b/types/valset_confirm.go
@@ -6,8 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var _ AttestationConfirm = &ValsetConfirm{}
-
 // ValsetConfirm
 // this is the message sent by the validators when they wish to submit their
 // signatures over the validator set at a given block height. A validators sign the validator set,
@@ -25,8 +23,8 @@ type ValsetConfirm struct {
 	Signature string
 }
 
-// NewMsgValsetConfirm returns a new msgValSetConfirm.
-func NewMsgValsetConfirm(
+// NewValsetConfirm returns a new msgValSetConfirm.
+func NewValsetConfirm(
 	ethAddress common.Address,
 	signature string,
 ) *ValsetConfirm {
@@ -55,8 +53,8 @@ func UnmarshalValsetConfirm(encoded []byte) (ValsetConfirm, error) {
 	return valsetConfirm, nil
 }
 
-// IsEmptyMsgValsetConfirm takes a msg valset confirm and checks if it is an empty one.
-func IsEmptyMsgValsetConfirm(vs ValsetConfirm) bool {
+// IsEmptyValsetConfirm takes a msg valset confirm and checks if it is an empty one.
+func IsEmptyValsetConfirm(vs ValsetConfirm) bool {
 	emptyVsConfirm := ValsetConfirm{}
 	return vs.EthAddress == emptyVsConfirm.EthAddress &&
 		vs.Signature == emptyVsConfirm.Signature


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

The `Msg` prefix was used as per the cosmos-sdk standard for naming messages. However, the confirms are no longer messages.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
