### PR TITLE
feat: reduce the routing table refresh period

### DIFF
--- a/p2p/dht.go
+++ b/p2p/dht.go
@@ -31,7 +31,7 @@ func NewQgbDHT(ctx context.Context, h host.Host, store ds.Batching) (*QgbDHT, er
 		dht.Datastore(store),
 		dht.Mode(dht.ModeServer),
 		dht.ProtocolPrefix(ProtocolPrefix),
-		dht.RoutingTableRefreshPeriod(time.Nanosecond), // TODO investigate which values to use
+		dht.RoutingTableRefreshPeriod(time.Minute),
 		dht.NamespacedValidator(DataCommitmentConfirmNamespace, DataCommitmentConfirmValidator{}),
 		dht.NamespacedValidator(ValsetConfirmNamespace, ValsetConfirmValidator{}),
 	)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Reduces the routing table refresh period to a more realistic period. The value is taken from Celestia-node repo.

For IPFS, the value is 10 minutes:

> To keep the routing tables accurate and up to date, IPFS refreshes the routing table every 10 minutes. While this is likely a higher frequency than is strictly necessary, it's important to protect the network's health as IPFS learns more about the dynamics of the DHT network. A routing table refresh works as follows:

source: https://docs.ipfs.tech/concepts/dht/#routing-tables

I guess 1 minute is a good value given that our P2P network is still new and experimental.
We can reduce that to even 1 hour once we have enough validators running orchestrators.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
