### PR TITLE
test: increase relayer test wait for height timeout

### DIFF
--- a/relayer/relayer_test.go
+++ b/relayer/relayer_test.go
@@ -2,6 +2,7 @@ package relayer_test
 
 import (
 	"context"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 
@@ -11,7 +12,7 @@ import (
 
 func (s *RelayerTestSuite) TestProcessAttestation() {
 	t := s.T()
-	_, err := s.Node.CelestiaNetwork.WaitForHeight(500)
+	_, err := s.Node.CelestiaNetwork.WaitForHeightWithTimeout(400, 30*time.Second)
 	require.NoError(t, err)
 
 	att := types.NewDataCommitment(2, 10, 100)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Fixes main. Using 10sec wait for 500 blocks creates flakiness. Sometimes the chain reaches that height in time, sometimes it doesn't and the tests fail.

This PR increases the timeout and decrease the wait to 400 blocks so it always passes.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
