### PR TITLE
fix: update query 2/3 valset confirms to use the previous valset

### DIFF
--- a/p2p/querier_test.go
+++ b/p2p/querier_test.go
@@ -115,8 +115,8 @@ func TestQueryTwoThirdsValsetConfirms(t *testing.T) {
 	ethAddr2 := common.HexToAddress("0xfA906e15C9Eaf338c4110f0E21983c6b3b2d622c")
 	ethAddr3 := common.HexToAddress("0xfA906e15C9Eaf338c4110f0E21983c6b3b2d622d")
 
-	valset := celestiatypes.Valset{
-		Nonce: vsNonce,
+	previousValset := celestiatypes.Valset{
+		Nonce: vsNonce - 1,
 		Members: []celestiatypes.BridgeValidator{
 			{
 				Power:      10,
@@ -149,7 +149,7 @@ func TestQueryTwoThirdsValsetConfirms(t *testing.T) {
 	querier := p2p.NewQuerier(network.DHTs[0], tmlog.NewNopLogger())
 
 	// query two thirds of confirms. should time-out.
-	confirms, err := querier.QueryTwoThirdsValsetConfirms(ctx, 10*time.Second, time.Millisecond, valset)
+	confirms, err := querier.QueryTwoThirdsValsetConfirms(ctx, 10*time.Second, time.Millisecond, vsNonce, previousValset)
 	require.Error(t, err)
 	require.Nil(t, confirms)
 
@@ -166,7 +166,7 @@ func TestQueryTwoThirdsValsetConfirms(t *testing.T) {
 	require.NoError(t, err)
 
 	// query two thirds of confirms. should return 2 confirms.
-	confirms, err = querier.QueryTwoThirdsValsetConfirms(ctx, 20*time.Second, time.Millisecond, valset)
+	confirms, err = querier.QueryTwoThirdsValsetConfirms(ctx, 20*time.Second, time.Millisecond, vsNonce, previousValset)
 	require.NoError(t, err)
 	assert.Contains(t, confirms, *vs1)
 	assert.Contains(t, confirms, *vs2)
@@ -184,7 +184,7 @@ func TestQueryTwoThirdsValsetConfirms(t *testing.T) {
 	require.NoError(t, err)
 
 	// query two thirds of confirms. should return 2 confirms.
-	confirms, err = querier.QueryTwoThirdsValsetConfirms(ctx, 20*time.Second, time.Millisecond, valset)
+	confirms, err = querier.QueryTwoThirdsValsetConfirms(ctx, 20*time.Second, time.Millisecond, vsNonce, previousValset)
 	require.NoError(t, err)
 	assert.Contains(t, confirms, *vs1)
 	assert.Contains(t, confirms, *vs2)
@@ -324,7 +324,7 @@ func TestQueryValsetConfirms(t *testing.T) {
 	querier := p2p.NewQuerier(network.DHTs[0], tmlog.NewNopLogger())
 
 	// query the confirms
-	confirms, err := querier.QueryValsetConfirms(ctx, valset)
+	confirms, err := querier.QueryValsetConfirms(ctx, valset.Nonce, valset)
 	require.NoError(t, err)
 	require.NotNil(t, confirms)
 	assert.Contains(t, confirms, *vs1)

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -120,7 +120,11 @@ func (r *Relayer) ProcessAttestation(ctx context.Context, opts *bind.TransactOpt
 		if !ok {
 			return nil, ErrAttestationNotValsetRequest
 		}
-		confirms, err := r.P2PQuerier.QueryTwoThirdsValsetConfirms(ctx, 30*time.Minute, 10*time.Second, *vs)
+		previousValset, err := r.AppQuerier.QueryLastValsetBeforeNonce(ctx, vs.Nonce)
+		if err != nil {
+			return nil, err
+		}
+		confirms, err := r.P2PQuerier.QueryTwoThirdsValsetConfirms(ctx, 30*time.Minute, 10*time.Second, vs.Nonce, *previousValset)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Closes https://github.com/celestiaorg/orchestrator-relayer/issues/180

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
