### PR TITLE
fix: build celestia-app using go 1.19 in e2e

### DIFF
--- a/e2e/Dockerfile_e2e
+++ b/e2e/Dockerfile_e2e
@@ -6,8 +6,6 @@ WORKDIR /orchestrator-relayer
 RUN make build
 
 # rebuild the celestia-app binary
-FROM golang:1.18-alpine as celestia-builder
-RUN apk update && apk --no-cache add make gcc musl-dev git
 WORKDIR /opt
 RUN git clone https://github.com/celestiaorg/celestia-app
 WORKDIR /opt/celestia-app


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Use the 1.19 go version to build Celestia-app in e2e tests

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
