### PR TITLE
docs: standardize titles for celestia docs & fix linting

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,4 +1,6 @@
-# Deploy
+# Deploy the QGB contract
+
+<!-- markdownlint-disable MD013 -->
 
 The `deploy` is a helper command that allows deploying the QGB smart contract to a new EVM chain:
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,4 +1,4 @@
-# Keys management
+# Key management
 
 <!-- markdownlint-disable MD013 -->
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,4 +1,6 @@
-# Keys
+# QGB keys subcommand
+
+<!-- markdownlint-disable MD013 -->
 
 The QGB `keys` command allows managing EVM private keys and P2P identities. It is defined as a subcommand for multiple commands with the only difference being the directory where the keys are stored. For the remaining functionality, it is the same for all the commands.
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,4 +1,4 @@
-# QGB keys subcommand
+# Keys subcommand
 
 <!-- markdownlint-disable MD013 -->
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,4 +1,4 @@
-# Keys subcommand
+# Keys management
 
 <!-- markdownlint-disable MD013 -->
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,4 +1,4 @@
-# QGB Orchestrator
+# Orchestrator
 
 <!-- markdownlint-disable MD013 -->
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,4 +1,6 @@
-# Orchestrator
+# QGB Orchestrator
+
+<!-- markdownlint-disable MD013 -->
 
 The role of the orchestrator is to sign attestations using its corresponding validator EVM private key. These attestations are generated within the QGB module of the Celestia-app state machine. To learn more about what attestations are, you can refer to this [link](https://github.com/celestiaorg/celestia-app/tree/main/x/qgb).
 

--- a/docs/relayer.md
+++ b/docs/relayer.md
@@ -1,4 +1,6 @@
-# Relayer
+# QGB Relayer
+
+<!-- markdownlint-disable MD013 -->
 
 The role of the relayer is to gather attestations' signatures from the orchestrators, and submit them to a target EVM chain. The attestations are generated within the QGB module of the Celestia-app state machine. To learn more about what attestations are, you can refer to this [link](https://github.com/celestiaorg/celestia-app/tree/main/x/qgb).
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR standardizes the titles that are being used in https://github.com/celestiaorg/docs/pull/668 and resolves [lint errors](https://github.com/celestiaorg/docs/actions/runs/4737250543/jobs/8409824190?pr=668) that occurred when the markdown was imported from the `orchestrator-relayer` repo.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
