### PR TITLE
test: wait also for second dht in test to pass before doing the checks

### DIFF
--- a/p2p/dht_test.go
+++ b/p2p/dht_test.go
@@ -45,6 +45,8 @@ func TestDHTBootstrappers(t *testing.T) {
 	// give some time for the routing table to be updated
 	err := dht1.WaitForPeers(ctx, 5*time.Second, time.Millisecond, 1)
 	require.NoError(t, err)
+	err = dht2.WaitForPeers(ctx, 5*time.Second, time.Millisecond, 1)
+	require.NoError(t, err)
 
 	// check if connected
 	require.NotEmpty(t, dht1.RoutingTable().ListPeers())


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This should fix a test that fails from time to time because the test isn't waiting for the second DHT routing table to populate:
https://github.com/celestiaorg/orchestrator-relayer/actions/runs/4773521264/jobs/8486641970
 
<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
