### PR TITLE
chore: replace string with constant in homeDir

### DIFF
--- a/cmd/qgb/deploy/cmd.go
+++ b/cmd/qgb/deploy/cmd.go
@@ -124,7 +124,7 @@ func Command() *cobra.Command {
 			return nil
 		},
 	}
-	command.AddCommand(keys.Command("deployer"))
+	command.AddCommand(keys.Command(ServiceNameDeployer))
 	return addDeployFlags(command)
 }
 

--- a/cmd/qgb/deploy/config.go
+++ b/cmd/qgb/deploy/config.go
@@ -10,12 +10,13 @@ import (
 )
 
 const (
-	FlagEVMAccAddress = "evm-address"
-	FlagEVMChainID    = "evm-chain-id"
-	FlagCelesGRPC     = "celes-grpc"
-	FlagEVMRPC        = "evm-rpc"
-	FlagStartingNonce = "starting-nonce"
-	FlagEVMGasLimit   = "evm-gas-limit"
+	FlagEVMAccAddress   = "evm-address"
+	FlagEVMChainID      = "evm-chain-id"
+	FlagCelesGRPC       = "celes-grpc"
+	FlagEVMRPC          = "evm-rpc"
+	FlagStartingNonce   = "starting-nonce"
+	FlagEVMGasLimit     = "evm-gas-limit"
+	ServiceNameDeployer = "deployer"
 )
 
 func addDeployFlags(cmd *cobra.Command) *cobra.Command {
@@ -33,7 +34,7 @@ func addDeployFlags(cmd *cobra.Command) *cobra.Command {
 			"\"nonce\": for the latest valset before the provided nonce, provided nonce included.",
 	)
 	cmd.Flags().Uint64P(FlagEVMGasLimit, "l", evm.DefaultEVMGasLimit, "Specify the evm gas limit")
-	homeDir, err := base.DefaultServicePath("deployer")
+	homeDir, err := base.DefaultServicePath(ServiceNameDeployer)
 	if err != nil {
 		panic(err)
 	}
@@ -86,7 +87,7 @@ func parseDeployFlags(cmd *cobra.Command) (deployConfig, error) {
 	}
 	if homeDir == "" {
 		var err error
-		homeDir, err = base.DefaultServicePath("deployer")
+		homeDir, err = base.DefaultServicePath(ServiceNameDeployer)
 		if err != nil {
 			return deployConfig{}, err
 		}

--- a/cmd/qgb/orchestrator/cmd.go
+++ b/cmd/qgb/orchestrator/cmd.go
@@ -25,7 +25,7 @@ func Command() *cobra.Command {
 	orchCmd.AddCommand(
 		Start(),
 		Init(),
-		keys.Command("orchestrator"),
+		keys.Command(ServiceNameOrchestrator),
 	)
 
 	orchCmd.SetHelpCommand(&cobra.Command{})

--- a/cmd/qgb/orchestrator/config.go
+++ b/cmd/qgb/orchestrator/config.go
@@ -9,12 +9,13 @@ import (
 )
 
 const (
-	FlagCelestiaGRPC     = "celes-grpc"
-	FlagEVMAccAddress    = "evm-address"
-	FlagTendermintRPC    = "celes-rpc"
-	FlagBootstrappers    = "p2p-bootstrappers"
-	FlagP2PListenAddress = "p2p-listen-addr"
-	FlagP2PNickname      = "p2p-nickname"
+	FlagCelestiaGRPC        = "celes-grpc"
+	FlagEVMAccAddress       = "evm-address"
+	FlagTendermintRPC       = "celes-rpc"
+	FlagBootstrappers       = "p2p-bootstrappers"
+	FlagP2PListenAddress    = "p2p-listen-addr"
+	FlagP2PNickname         = "p2p-nickname"
+	ServiceNameOrchestrator = "orchestrator"
 )
 
 func addOrchestratorFlags(cmd *cobra.Command) *cobra.Command {
@@ -29,7 +30,7 @@ func addOrchestratorFlags(cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(FlagBootstrappers, "b", "", "Comma-separated multiaddresses of p2p peers to connect to")
 	cmd.Flags().StringP(FlagP2PNickname, "p", "", "Nickname of the p2p private key to use (if not provided, an existing one from the p2p store or a newly generated one will be used)")
 	cmd.Flags().StringP(FlagP2PListenAddress, "q", "/ip4/0.0.0.0/tcp/30000", "MultiAddr for the p2p peer to listen on")
-	homeDir, err := base.DefaultServicePath("orchestrator")
+	homeDir, err := base.DefaultServicePath(ServiceNameOrchestrator)
 	if err != nil {
 		panic(err)
 	}
@@ -81,7 +82,7 @@ func parseOrchestratorFlags(cmd *cobra.Command) (StartConfig, error) {
 	}
 	if homeDir == "" {
 		var err error
-		homeDir, err = base.DefaultServicePath("orchestrator")
+		homeDir, err = base.DefaultServicePath(ServiceNameOrchestrator)
 		if err != nil {
 			return StartConfig{}, err
 		}
@@ -106,7 +107,7 @@ func parseOrchestratorFlags(cmd *cobra.Command) (StartConfig, error) {
 }
 
 func addInitFlags(cmd *cobra.Command) *cobra.Command {
-	homeDir, err := base.DefaultServicePath("orchestrator")
+	homeDir, err := base.DefaultServicePath(ServiceNameOrchestrator)
 	if err != nil {
 		panic(err)
 	}
@@ -125,7 +126,7 @@ func parseInitFlags(cmd *cobra.Command) (InitConfig, error) {
 	}
 	if homeDir == "" {
 		var err error
-		homeDir, err = base.DefaultServicePath("orchestrator")
+		homeDir, err = base.DefaultServicePath(ServiceNameOrchestrator)
 		if err != nil {
 			return InitConfig{}, err
 		}

--- a/cmd/qgb/relayer/cmd.go
+++ b/cmd/qgb/relayer/cmd.go
@@ -28,7 +28,7 @@ func Command() *cobra.Command {
 	relCmd.AddCommand(
 		Start(),
 		Init(),
-		keys.Command("relayer"),
+		keys.Command(ServiceNameRelayer),
 	)
 
 	relCmd.SetHelpCommand(&cobra.Command{})

--- a/cmd/qgb/relayer/config.go
+++ b/cmd/qgb/relayer/config.go
@@ -25,6 +25,7 @@ const (
 	FlagBootstrappers    = "p2p-bootstrappers"
 	FlagP2PListenAddress = "p2p-listen-addr"
 	FlagP2PNickname      = "p2p-nickname"
+	ServiceNameRelayer   = "relayer"
 )
 
 func addRelayerStartFlags(cmd *cobra.Command) *cobra.Command {
@@ -38,7 +39,7 @@ func addRelayerStartFlags(cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().StringP(FlagBootstrappers, "b", "", "Comma-separated multiaddresses of p2p peers to connect to")
 	cmd.Flags().StringP(FlagP2PNickname, "p", "", "Nickname of the p2p private key to use (if not provided, an existing one from the p2p store or a newly generated one will be used)")
 	cmd.Flags().StringP(FlagP2PListenAddress, "q", "/ip4/127.0.0.1/tcp/30000", "MultiAddr for the p2p peer to listen on")
-	homeDir, err := base.DefaultServicePath("relayer")
+	homeDir, err := base.DefaultServicePath(ServiceNameRelayer)
 	if err != nil {
 		panic(err)
 	}
@@ -116,7 +117,7 @@ func parseRelayerStartFlags(cmd *cobra.Command) (StartConfig, error) {
 	}
 	if homeDir == "" {
 		var err error
-		homeDir, err = base.DefaultServicePath("relayer")
+		homeDir, err = base.DefaultServicePath(ServiceNameRelayer)
 		if err != nil {
 			return StartConfig{}, err
 		}
@@ -145,7 +146,7 @@ func parseRelayerStartFlags(cmd *cobra.Command) (StartConfig, error) {
 }
 
 func addInitFlags(cmd *cobra.Command) *cobra.Command {
-	homeDir, err := base.DefaultServicePath("relayer")
+	homeDir, err := base.DefaultServicePath(ServiceNameRelayer)
 	if err != nil {
 		panic(err)
 	}
@@ -164,7 +165,7 @@ func parseInitFlags(cmd *cobra.Command) (InitConfig, error) {
 	}
 	if homeDir == "" {
 		var err error
-		homeDir, err = base.DefaultServicePath("relayer")
+		homeDir, err = base.DefaultServicePath(ServiceNameRelayer)
 		if err != nil {
 			return InitConfig{}, err
 		}


### PR DESCRIPTION
## Overview
1.  open [isssue](https://github.com/celestiaorg/orchestrator-relayer/issues/320). 
2. homeDir servic-name "relayer" was used as a string in cmd and config. Replaced with constant. 

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
