### PR TITLE
fix: link to docs, instead of readme

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -34,7 +34,7 @@ Use "qgb deploy [command] --help" for more information about a command.
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/README.md) for more details.
+Make sure to have the QGB binary installed. Check [here](./qgb-binary.md) for more details.
 
 ### Add keys
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -34,7 +34,7 @@ Use "qgb deploy [command] --help" for more information about a command.
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](./qgb-binary.md) for more details.
+Make sure to have the QGB binary installed. Check [here](https://docs.celestia.org/nodes/qgb-binary) for more details.
 
 ### Add keys
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -29,7 +29,7 @@ I[2023-04-26|00:04:28.175] waiting for routing table to populate        targetnu
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/README.md) for more details.
+Make sure to have the QGB binary installed. Check [here](./qgb-binary.md) for more details.
 
 ### Init the store
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -29,7 +29,7 @@ I[2023-04-26|00:04:28.175] waiting for routing table to populate        targetnu
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](./qgb-binary.md) for more details.
+Make sure to have the QGB binary installed. Check [here](https://docs.celestia.org/nodes/qgb-binary) for more details.
 
 ### Init the store
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -29,7 +29,7 @@ I[2023-04-26|00:04:28.175] waiting for routing table to populate        targetnu
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](https://docs.celestia.org/nodes/qgb-binary) for more details
+Make sure to have the QGB binary installed. Check [here](https://docs.celestia.org/nodes/qgb-binary) for more details.
 
 ### Init the store
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -29,7 +29,7 @@ I[2023-04-26|00:04:28.175] waiting for routing table to populate        targetnu
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](https://docs.celestia.org/nodes/qgb-binary) for more details.
+Make sure to have the QGB binary installed. Check [here](https://docs.celestia.org/nodes/qgb-binary) for more details
 
 ### Init the store
 

--- a/docs/relayer.md
+++ b/docs/relayer.md
@@ -33,7 +33,7 @@ I[2023-04-26|00:04:28.175] waiting for routing table to populate        targetnu
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](./qgb-binary.md) for more details.
+Make sure to have the QGB binary installed. Check [here](https://docs.celestia.org/nodes/qgb-binary) for more details.
 
 ### Init the store
 

--- a/docs/relayer.md
+++ b/docs/relayer.md
@@ -33,7 +33,7 @@ I[2023-04-26|00:04:28.175] waiting for routing table to populate        targetnu
 
 ### Install the QGB binary
 
-Make sure to have the QGB binary installed. Check [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/README.md) for more details.
+Make sure to have the QGB binary installed. Check [here](./qgb-binary.md) for more details.
 
 ### Init the store
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR links to the Celestia docs pages, instead of to the docs in the `orchestrator-relayer` repository.

The reasoning is that if we use relative links for docs i.e. `../qgb-binary.md`, it will break the links in the docs on the repository.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
