### PR TITLE
fix!: dirty hack to signing successfully the first data commitment range

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -336,6 +336,9 @@ func (orch Orchestrator) Process(ctx context.Context, nonce uint64) error {
 		if !ok {
 			return errors.Wrap(types.ErrAttestationNotDataCommitmentRequest, strconv.FormatUint(nonce, 10))
 		}
+		if dc.BeginBlock == 0 {
+			dc.BeginBlock = 1
+		}
 		commitment, err := orch.TmQuerier.QueryCommitment(
 			ctx,
 			dc.BeginBlock,


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This is because we included the  latest core release in the app v0.13.2 without including the corresponding change in the state machine.

For BSR, this case will never be hit since we will stop at the last unbonding height. But, I think it's better if we have the E2E passing to be more sure this is working.

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
