### PR TITLE
chore: pretty print listen addresses

### DIFF
--- a/cmd/qgb/common/helpers.go
+++ b/cmd/qgb/common/helpers.go
@@ -85,7 +85,7 @@ func CreateDHTAndWaitForPeers(
 	if err != nil {
 		return nil, err
 	}
-	logger.Info("created host")
+	logger.Info("created P2P host")
 
 	prettyPrintHost(h)
 

--- a/cmd/qgb/common/helpers.go
+++ b/cmd/qgb/common/helpers.go
@@ -2,8 +2,11 @@ package common
 
 import (
 	"context"
+	"fmt"
 	"strings"
 	"time"
+
+	"github.com/libp2p/go-libp2p/core/host"
 
 	evm2 "github.com/celestiaorg/orchestrator-relayer/cmd/qgb/keys/evm"
 	"github.com/celestiaorg/orchestrator-relayer/store"
@@ -82,13 +85,9 @@ func CreateDHTAndWaitForPeers(
 	if err != nil {
 		return nil, err
 	}
-	logger.Info(
-		"created host",
-		"ID",
-		h.ID().String(),
-		"Addresses",
-		h.Addrs(),
-	)
+	logger.Info("created host")
+
+	prettyPrintHost(h)
 
 	// get the bootstrappers
 	var aIBootstrappers []peer.AddrInfo
@@ -114,6 +113,14 @@ func CreateDHTAndWaitForPeers(
 		return nil, err
 	}
 	return dht, nil
+}
+
+func prettyPrintHost(h host.Host) {
+	fmt.Printf("ID: %s\n", h.ID().String())
+	fmt.Println("Listen addresses:")
+	for _, addr := range h.Addrs() {
+		fmt.Printf("\t%s\n", addr.String())
+	}
 }
 
 // InitBase initializes the base components for the orchestrator and relayer.


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Closes: https://github.com/celestiaorg/orchestrator-relayer/issues/146

the output now is:
```
I[2023-06-20|16:59:54.071] loading EVM account                          address=0x966e6f22781EF6a6A82BBB4DB3df8E225DfD9488
I[2023-06-20|16:59:55.023] created host                                 
ID: 12D3KooWFb6jzki62cpRo87YWcwdJWwSADScEsNuCxiwa9xcQvQx
Listen addresses:
	/ip4/192.168.1.11/tcp/30000
	/ip4/127.0.0.1/tcp/30000
I[2023-06-20|17:00:05.024] waiting for routing table to populate        targetnumberofpeers=1 currentcount=0
```

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
