### PR TITLE
documentation: match frontmatter on docs site .md files

### DIFF
--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -1,3 +1,8 @@
+---
+sidebar_label: Deploy the QGB contract
+description: Learn how to deploy the QGB smart contract.
+---
+
 # Deploy the QGB contract
 
 <!-- markdownlint-disable MD013 -->

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -1,3 +1,8 @@
+---
+sidebar_label: Key management
+description: Learn how to manage EVM private keys and P2P identities.
+---
+
 # Key management
 
 <!-- markdownlint-disable MD013 -->

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -1,3 +1,8 @@
+---
+sidebar_label: QGB Orchestrator
+description: Learn about the QGB Orchestrator.
+---
+
 # QGB Orchestrator
 
 <!-- markdownlint-disable MD013 -->

--- a/docs/relayer.md
+++ b/docs/relayer.md
@@ -1,3 +1,8 @@
+---
+sidebar_label: QGB Relayer
+description: Learn about the QGB Relayer.
+---
+
 # QGB Relayer
 
 <!-- markdownlint-disable MD013 -->


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR matches the frontmatter (metadata) config on the Celestia docs site. This is being added to the source on the orchestrator-relayer repository as it will prevent the frontmatter from being removed when imported from this repository.

You can see in this [commit (ignore edit to package.json)](https://github.com/celestiaorg/docs/pull/1045/commits/6f5b05c04fe01015165244e80224fa5724f604de), a demonstration of what it would look like if the `importMarkdown.mjs` ran when the frontmatter does not exist on this source repository. This resolves #463 

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
