### PR TITLE
chore: reduce the default EVM gas limit

### DIFF
--- a/evm/evm_client.go
+++ b/evm/evm_client.go
@@ -20,7 +20,7 @@ import (
 )
 
 // DefaultEVMGasLimit the default gas limit to use when sending transactions to the EVM chain.
-const DefaultEVMGasLimit = uint64(25000000)
+const DefaultEVMGasLimit = uint64(2500000)
 
 type Client struct {
 	logger   tmlog.Logger


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Currently, relaying attestations takes around 550000 gas, and deploying the contracts around 1250000 gas. So, we can reduce the default gas limit to a more realistic value.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
