### PR TITLE
fix: make the orchestrator sign by default

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -300,29 +300,17 @@ func (orch Orchestrator) Process(ctx context.Context, nonce uint64) error {
 	if att == nil {
 		return celestiatypes.ErrAttestationNotFound
 	}
-	// check if the validator is part of the needed valset
-	var previousValset *celestiatypes.Valset
-	if att.GetNonce() == 1 {
-		// if nonce == 1, then, the current valset should sign the confirm.
-		// In fact, the first nonce should never be signed. Because, the first attestation, in the case
-		// where the `earliest` flag is specified when deploying the contract, will be relayed as part of
-		// the deployment of the QGB contract.
-		// It will be signed temporarily for now.
-		previousValset, err = orch.AppQuerier.QueryValsetByNonce(ctx, att.GetNonce())
-		if err != nil {
-			return err
-		}
-	} else {
-		previousValset, err = orch.AppQuerier.QueryLastValsetBeforeNonce(ctx, att.GetNonce())
-		if err != nil {
-			return err
-		}
-	}
-	if !ValidatorPartOfValset(previousValset.Members, orch.EvmAccount.Address.Hex()) {
+
+	// check if we need to sign or not
+	previousValset, err := orch.AppQuerier.QueryLastValsetBeforeNonce(ctx, att.GetNonce())
+	if err != nil {
+		orch.Logger.Debug("failed to query last valset before nonce (most likely pruned). signing anyway", "err", err.Error())
+	} else if !ValidatorPartOfValset(previousValset.Members, orch.EvmAccount.Address.Hex()) {
 		// no need to sign if the orchestrator is not part of the validator set that needs to sign the attestation
 		orch.Logger.Debug("validator not part of valset. won't sign", "nonce", nonce)
 		return nil
 	}
+
 	switch castedAtt := att.(type) {
 	case *celestiatypes.Valset:
 		signBytes, err := castedAtt.SignBytes()

--- a/orchestrator/suite_test.go
+++ b/orchestrator/suite_test.go
@@ -26,9 +26,13 @@ func (s *OrchestratorTestSuite) SetupSuite() {
 	s.Node = qgbtesting.NewTestNode(
 		ctx,
 		t,
-		testnode.ImmediateProposals(codec),
-		qgbtesting.SetDataCommitmentWindowParams(codec, types.Params{DataCommitmentWindow: 101}),
-		// qgbtesting.SetVotingParams(codec, v1beta1.VotingParams{VotingPeriod: 100 * time.Hour}),
+		qgbtesting.CelestiaNetworkParams{
+			GenesisOpts: []testnode.GenesisOption{
+				testnode.ImmediateProposals(codec),
+				qgbtesting.SetDataCommitmentWindowParams(codec, types.Params{DataCommitmentWindow: 101}),
+			},
+			TimeIotaMs: 1,
+		},
 	)
 	s.Orchestrator = qgbtesting.NewOrchestrator(t, s.Node)
 }

--- a/relayer/suite_test.go
+++ b/relayer/suite_test.go
@@ -26,7 +26,7 @@ func (s *RelayerTestSuite) SetupSuite() {
 		t.Skip("skipping relayer tests in short mode.")
 	}
 	ctx := context.Background()
-	s.Node = qgbtesting.NewTestNode(ctx, t)
+	s.Node = qgbtesting.NewTestNode(ctx, t, qgbtesting.DefaultCelestiaNetworkParams())
 	_, err := s.Node.CelestiaNetwork.WaitForHeight(2)
 	require.NoError(t, err)
 	s.Orchestrator = qgbtesting.NewOrchestrator(t, s.Node)

--- a/rpc/suite_test.go
+++ b/rpc/suite_test.go
@@ -25,7 +25,7 @@ type QuerierTestSuite struct {
 func (s *QuerierTestSuite) SetupSuite() {
 	t := s.T()
 	ctx := context.Background()
-	s.Network = qgbtesting.NewCelestiaNetwork(ctx, t)
+	s.Network = qgbtesting.NewCelestiaNetwork(ctx, t, qgbtesting.DefaultCelestiaNetworkParams())
 	_, err := s.Network.WaitForHeightWithTimeout(400, 30*time.Second)
 	s.EncConf = encoding.MakeConfig(app.ModuleEncodingRegisters...)
 	s.Logger = tmlog.NewNopLogger()

--- a/testing/celestia_network.go
+++ b/testing/celestia_network.go
@@ -41,10 +41,22 @@ type CelestiaNetwork struct {
 	GRPCAddr string
 }
 
+type CelestiaNetworkParams struct {
+	GenesisOpts []celestiatestnode.GenesisOption
+	TimeIotaMs  int64
+}
+
+func DefaultCelestiaNetworkParams() CelestiaNetworkParams {
+	return CelestiaNetworkParams{
+		GenesisOpts: nil,
+		TimeIotaMs:  1,
+	}
+}
+
 // NewCelestiaNetwork creates a new CelestiaNetwork.
 // Uses `testing.T` to fail if an error happens.
 // Only supports the creation of a single validator currently.
-func NewCelestiaNetwork(ctx context.Context, t *testing.T, genesisOpts ...celestiatestnode.GenesisOption) *CelestiaNetwork {
+func NewCelestiaNetwork(ctx context.Context, t *testing.T, params CelestiaNetworkParams) *CelestiaNetwork {
 	if testing.Short() {
 		// The main reason for skipping these tests in short mode is to avoid detecting unrelated
 		// race conditions.
@@ -63,14 +75,17 @@ func NewCelestiaNetwork(ctx context.Context, t *testing.T, genesisOpts ...celest
 	tmCfg := celestiatestnode.DefaultTendermintConfig()
 	tmCfg.Consensus.TimeoutCommit = time.Millisecond * 5
 	appConf := celestiatestnode.DefaultAppConfig()
+	consensusParams := celestiatestnode.DefaultParams()
+	consensusParams.Block.TimeIotaMs = params.TimeIotaMs
 
 	clientContext, _, _ := celestiatestnode.NewNetwork(
 		t,
 		celestiatestnode.DefaultConfig().
 			WithAppConfig(appConf).
+			WithConsensusParams(consensusParams).
 			WithTendermintConfig(tmCfg).
 			WithAccounts(accounts).
-			WithGenesisOptions(genesisOpts...).
+			WithGenesisOptions(params.GenesisOpts...).
 			WithChainID("qgb-test"),
 	)
 

--- a/testing/testnode.go
+++ b/testing/testnode.go
@@ -3,8 +3,6 @@ package testing
 import (
 	"context"
 	"testing"
-
-	celestiatestnode "github.com/celestiaorg/celestia-app/test/util/testnode"
 )
 
 // TestNode contains a DHTNetwork along with a test Celestia network and a simulated EVM chain.
@@ -15,8 +13,8 @@ type TestNode struct {
 	EVMChain        *EVMChain
 }
 
-func NewTestNode(ctx context.Context, t *testing.T, genesisOpts ...celestiatestnode.GenesisOption) *TestNode {
-	celestiaNetwork := NewCelestiaNetwork(ctx, t, genesisOpts...)
+func NewTestNode(ctx context.Context, t *testing.T, celestiaParams CelestiaNetworkParams) *TestNode {
+	celestiaNetwork := NewCelestiaNetwork(ctx, t, celestiaParams)
 	dhtNetwork := NewDHTNetwork(ctx, 2)
 
 	evmChain := NewEVMChain(NodeEVMPrivateKey)


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Closes https://github.com/celestiaorg/orchestrator-relayer/issues/513

This makes the orchestrator signs by default, instead of needing to be part of a valset to sign. The only case it doesn't sign is when it finds a valset and it's not part of it.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
