### PR TITLE
chore: not sign nonce 1

### DIFF
--- a/orchestrator/orchestrator.go
+++ b/orchestrator/orchestrator.go
@@ -302,13 +302,15 @@ func (orch Orchestrator) Process(ctx context.Context, nonce uint64) error {
 	}
 
 	// check if we need to sign or not
-	previousValset, err := orch.AppQuerier.QueryLastValsetBeforeNonce(ctx, att.GetNonce())
-	if err != nil {
-		orch.Logger.Debug("failed to query last valset before nonce (most likely pruned). signing anyway", "err", err.Error())
-	} else if !ValidatorPartOfValset(previousValset.Members, orch.EvmAccount.Address.Hex()) {
-		// no need to sign if the orchestrator is not part of the validator set that needs to sign the attestation
-		orch.Logger.Debug("validator not part of valset. won't sign", "nonce", nonce)
-		return nil
+	if nonce != 1 {
+		previousValset, err := orch.AppQuerier.QueryLastValsetBeforeNonce(ctx, att.GetNonce())
+		if err != nil {
+			orch.Logger.Debug("failed to query last valset before nonce (most likely pruned). signing anyway", "err", err.Error())
+		} else if !ValidatorPartOfValset(previousValset.Members, orch.EvmAccount.Address.Hex()) {
+			// no need to sign if the orchestrator is not part of the validator set that needs to sign the attestation
+			orch.Logger.Debug("validator not part of valset. won't sign", "nonce", nonce)
+			return nil
+		}
 	}
 
 	switch castedAtt := att.(type) {


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

After thinking about this, there is no need to sign nonce 1 at all because if it is used, it will be the point of initialization of the QGB contract, thus, no need to sign it.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
