### PR TITLE
chore: resolve issues on docs runtime with use of ssh instead of sh 

### DIFF
--- a/docs/bootstrapper.md
+++ b/docs/bootstrapper.md
@@ -12,7 +12,7 @@ Make sure to have the Blobstream binary installed. Check [the Blobstream binary 
 
 Before starting the bootstrapper, we will need to init the store:
 
-```ssh
+```sh
 blobstream bootstrapper init
 ```
 
@@ -28,7 +28,7 @@ The P2P private key is optional, and a new one will be generated automatically o
 
 The `p2p` sub-command will help you set up this key if you want to use a specific one:
 
-```ssh
+```sh
 blobstream bootstrapper p2p  --help
 ```
 

--- a/docs/deploy.md
+++ b/docs/deploy.md
@@ -9,7 +9,7 @@ description: Learn how to deploy the Blobstream smart contract.
 
 The `deploy` is a helper command that allows deploying the Blobstream smart contract to a new EVM chain:
 
-```ssh
+```sh
 blobstream deploy --help
 
 Deploys the Blobstream contract and initializes it using the provided Celestia chain
@@ -32,13 +32,13 @@ Make sure to have the Blobstream binary installed. Check [the Blobstream binary 
 
 In order to deploy a Blobstream smart contract, you will need a funded EVM address and its private key. The `keys` command will help you set up this key:
 
-```ssh
+```sh
 blobstream deploy keys  --help
 ```
 
 To import your EVM private key, there is the `import` subcommand to assist you with that:
 
-```ssh
+```sh
 blobstream deploy keys evm import --help
 ```
 
@@ -46,7 +46,7 @@ This subcommand allows you to either import a raw ECDSA private key provided as 
 
 After adding the key, you can check that it's added via running:
 
-```ssh
+```sh
 blobstream deploy keys evm list
 ```
 
@@ -56,7 +56,7 @@ For more information about the `keys` command, check [the `keys` documentation](
 
 Now, we can deploy the Blobstream contract to a new EVM chain:
 
-```ssh
+```sh
 blobstream deploy \
   --evm.chain-id 4 \
   --evm.contract-address 0x27a1F8CE94187E4b043f4D57548EF2348Ed556c7 \

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -47,7 +47,7 @@ As specified above, aside from the difference in the default home directory, the
 
 The examples will use the orchestrator command to access the keys. However, the same behaviour applies to the other commands as well.
 
-```ssh
+```sh
 blobstream orchestrator keys --help
 
 Blobstream keys manager
@@ -71,7 +71,7 @@ The first subcommand of the `keys` command is `evm`. This latter allows managing
 
 The EVM keys are `ECDSA` keys using the `secp256k1` curve. The implementation uses `geth` file system keystore [implementation](https://geth.ethereum.org/docs/developers/dapp-developer/native-accounts). Thus, keys can be used interchangeably with any compatible software.
 
-```ssh
+```sh
 blobstream orchestrator keys evm --help
 
 Blobstream EVM keys manager
@@ -102,7 +102,7 @@ evmKs = keystore.NewKeyStore(evmKeyStorePath(path), keystore.StandardScryptN, ke
 
 The `add` subcommand allows creating a new EVM private key and storing it in the keystore:
 
-```ssh
+```sh
 blobstream orchestrator keys evm add --help
 
 create a new EVM address
@@ -115,7 +115,7 @@ The passphrase of the key encryption can be passed as a flag. But it is advised 
 
 After creating a new key, you will see its corresponding address printed:
 
-```ssh
+```sh
 blobstream orchestrator keys evm add
 
 I[2023-04-13|14:16:11.387] successfully opened store                    path=/home/midnight/.orchestrator
@@ -128,7 +128,7 @@ I[2023-04-13|14:16:30.534] successfully closed store                    path=/ho
 
 The `delete` subcommand allows deleting an EVM private key from store via providing its corresponding address:
 
-```ssh
+```sh
 blobstream orchestrator keys evm delete --help
 
 delete an EVM addresses from the key store
@@ -143,7 +143,7 @@ After running the command, you will be prompted to enter the passphrase for the 
 
 Then, you will be prompted to confirm that you want to delete that private key. Make sure to verify if you're deleting the right one because once deleted, it can no longer be recovered!
 
-```ssh
+```sh
 blobstream orchestrator keys evm delete 0x27a1F8CE94187E4b043f4D57548EF2348Ed556c7
 
 I[2023-04-13|15:01:41.308] successfully opened store                    path=/home/midnight/.orchestrator
@@ -159,7 +159,7 @@ I[2023-04-13|15:01:45.534] successfully closed store                    path=/ho
 
 The `list` subcommand allows listing the existing keys in the keystore:
 
-```ssh
+```sh
 blobstream orchestrator keys evm list
 
 I[2023-04-13|16:08:45.084] successfully opened store                    path=/home/midnight/.orchestrator
@@ -174,7 +174,7 @@ You could specify a different home using the `--home` flag to list the keys in a
 
 The `update` subcommand allows changing the EVM private key passphrase to a new one. It takes as argument the `0x` prefixed EVM address corresponding to the private key we want to edit.
 
-```ssh
+```sh
 blobstream orchestrator evm update --help
 
 update an EVM account passphrase
@@ -185,7 +185,7 @@ Usage:
 
 Example:
 
-```ssh
+```sh
 blobstream orchestrator evm update 0x7Dd8F9CAfe6D25165249A454F2d0b72FD149Bbba
 
 I[2023-04-13|16:21:17.139] successfully opened store                    path=/home/midnight/.orchestrator
@@ -204,7 +204,7 @@ The `--home` can be specified if the store is not in the default directory.
 
 The `import` subcommand allows importing existing private keys into the keystore. It has two subcommands: `ecdsa` and `file`. The first allows importing a private key in plaintext, while the other allows importing a private key from a JSON file secured with a passphrase.
 
-```ssh
+```sh
 blobstream orchestrator keys evm import --help
 
 import evm keys to the keystore
@@ -228,7 +228,7 @@ For the first one, it takes as argument the private key in plaintext. Then, it p
 
 Example:
 
-```ssh
+```sh
 blobstream orchestrator keys evm import ecdsa da6ed55cb2894ac2c9c10209c09de8e8b9d109b910338d5bf3d747a7e1fc9eb7
 
 I[2023-04-13|17:00:48.617] successfully opened store                    path=/home/midnight/.orchestrator
@@ -242,7 +242,7 @@ I[2023-04-13|17:00:51.990] successfully closed store                    path=/ho
 
 For the second, it takes a JSON key file, as defined in [@ethereum/eth-keyfile](https://github.com/ethereum/eth-keyfile), and imports it to your keystore, so it can be used for signatures.
 
-```ssh
+```sh
 blobstream orchestrator keys evm import file --help
 
 import an EVM address from a file
@@ -253,7 +253,7 @@ Usage:
 
 For example, if we have a file in the current directory containing a private key, we could run the following:
 
-```ssh
+```sh
 blobstream orchestrator keys evm import file UTC--2023-04-13T15-00-50.302148204Z--966e6f22781ef6a6a82bbb4db3df8e225dfd9488
 
 I[2023-04-13|17:31:53.307] successfully opened store                    path=/home/midnight/.orchestrator
@@ -272,7 +272,7 @@ Similar to the above EVM keystore, the P2P store has similar subcommands for han
 
 To access the P2P keystore, run the following:
 
-```ssh
+```sh
 blobstream orchestrator keys p2p
 
 Blobstream p2p keys manager
@@ -298,7 +298,7 @@ The `orchestrator` could be replaced by `relayer` and the only difference would 
 
 The `add` subcommand creates a new p2p key to the p2p store:
 
-```ssh
+```sh
 blobstream orchestrator keys p2p add --help
 
 create a new Ed25519 P2P address
@@ -309,7 +309,7 @@ Usage:
 
 It takes as argument an optional `<nickname>` which would be the name that we can use to reference that private key. If not specified, an incremental nickname will be assigned.
 
-```ssh
+```sh
 blobstream orchestrator keys p2p add
 
 I[2023-04-13|17:38:17.289] successfully opened store                    path=/home/midnight/.orchestrator
@@ -326,7 +326,7 @@ The nickname will be needed in case the orchestrator needs to use a specific pri
 
 The `delete` subcommand will delete a P2P private key from store referenced by its nickname:
 
-```ssh
+```sh
 blobstream orchestrator keys p2p delete --help
 
 delete an Ed25519 P2P private key from store
@@ -339,7 +339,7 @@ Usage:
 
 The `import` subcommand will import an existing Ed25519 private key to the store. It takes as argument the nickname that we wish to save the private key under, and the actual private key in hex format without `0x`:
 
-```ssh
+```sh
 blobstream orchestrator keys p2p import --help
 
 import an existing p2p private key
@@ -352,7 +352,7 @@ Usage:
 
 The `list` subcommand lists the existing P2P private keys in the store:
 
-```ssh
+```sh
 blobstream orchestrator keys p2p list --help
 
 list existing p2p addresses

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -16,7 +16,7 @@ The orchestrator does the following:
 
 1. Connect to a Celestia-app full node or validator node via RPC and gRPC and wait for new attestations
 2. Once an attestation is created inside the Blobstream state machine, the orchestrator queries it.
-3. After getting the attestation, the orchestrator signs it using the provided EVM private key. The private key should correspond to the EVM address provided when creating the validator. Read [more about Blobstream keys](https://docs.celestia.org/nodes/blobstream-keys).
+3. After getting the attestation, the orchestrator signs it using the provided EVM private key. The private key should correspond to the EVM address provided when creating the validator. Read [more about Blobstream keys](https://docs.celestia.org/nodes/blobstream-keys/).
 4. Then, the orchestrator pushes its signature to the P2P network it is connected to, via adding it as a DHT value.
 5. Listen for new attestations and go back to step 2.
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -16,7 +16,7 @@ The orchestrator does the following:
 
 1. Connect to a Celestia-app full node or validator node via RPC and gRPC and wait for new attestations
 2. Once an attestation is created inside the Blobstream state machine, the orchestrator queries it.
-3. After getting the attestation, the orchestrator signs it using the provided EVM private key. The private key should correspond to the EVM address provided when creating the validator. Read [more about Blobstream keys](https://docs.celestia.org/nodes/blobstream-keys/).
+3. After getting the attestation, the orchestrator signs it using the provided EVM private key. The private key should correspond to the EVM address provided when creating the validator. Read [more about Blobstream keys](https://docs.celestia.org/nodes/blobstream-keys).
 4. Then, the orchestrator pushes its signature to the P2P network it is connected to, via adding it as a DHT value.
 5. Listen for new attestations and go back to step 2.
 

--- a/docs/orchestrator.md
+++ b/docs/orchestrator.md
@@ -54,7 +54,7 @@ Make sure to have the Blobstream binary installed. Check [the Blobstream binary 
 
 Before starting the orchestrator, we will need to init the store:
 
-```ssh
+```sh
 blobstream orchestrator init
 ```
 
@@ -77,7 +77,7 @@ The P2P private key is optional, and a new one will be generated automatically o
 
 The `keys` command will help you set up these keys:
 
-```ssh
+```sh
 blobstream orchestrator keys  --help
 ```
 
@@ -91,7 +91,7 @@ To register an EVM address for your validator, check the section [Register EVM A
 
 To import your EVM private key, there is the `import` subcommand to assist you with that:
 
-```ssh
+```sh
 blobstream orchestrator keys evm import --help
 ```
 
@@ -99,7 +99,7 @@ This subcommand allows you to either import a raw ECDSA private key provided as 
 
 After adding the key, you can check that it's added via running:
 
-```ssh
+```sh
 blobstream orchestrator keys evm list
 ```
 
@@ -111,7 +111,7 @@ Now that we have the store initialized, we can start the orchestrator. Make sure
 
 The orchestrator accepts the following flags:
 
-```ssh
+```sh
 blobstream orchestrator start --help
 
 Starts the Blobstream orchestrator to sign attestations
@@ -122,7 +122,7 @@ Usage:
 
 To start the orchestrator in the default home directory, run the following:
 
-```ssh
+```sh
 blobstream orchestrator start \
     --core.grpc.host localhost \
     --core.grpc.port 9090 \
@@ -151,7 +151,7 @@ To edit an EVM address for a certain validator, its corresponding account needs 
 
 First, you should get your validator `valoper` address. To do so, run the following:
 
-```ssh
+```sh
 celestia-appd keys show <validator_account> --bech val
 ```
 
@@ -159,7 +159,7 @@ This assumes that you're using the default home directory, the default keystore 
 
 To check which EVM address is registered for your `valoper` address, run the following:
 
-```ssh
+```sh
 celestia-appd query blobstream evm <validator_valoper_address>
 ```
 
@@ -176,7 +176,7 @@ celestia-appd tx blobstream register \
 
 Example command output:
 
-```ssh
+```sh
 code: 0
 codespace: ""
 data: 12300A2E2F63656C65737469612E7167622E76312E4D7367526567697374657245564D41646472657373526573706F6E7365
@@ -256,7 +256,7 @@ txhash: 4199EA959A2CFEFCD4726D8D8F7B536458A46A27318D3483A4E9614F560606BC
 
 Now, you can verify that the EVM address has been updated using the following command:
 
-```ssh
+```sh
 celestia-appd query blobstream evm <validator_valoper_address>
 ```
 

--- a/docs/relayer.md
+++ b/docs/relayer.md
@@ -9,9 +9,9 @@ description: Learn about the Blobstream Relayer.
 
 The role of the relayer is to gather attestations' signatures from the orchestrators, and submit them to a target EVM chain. The attestations are generated within the Blobstream module of the Celestia-app state machine. To learn more about what attestations are, you can refer to [the Blobstream overview](https://github.com/celestiaorg/celestia-app/tree/main/x/blobstream).
 
-Also, while every validator in the Celestia validator set needs to run an orchestrator, we only need one entity to run the relayer, and it can be anyone. Thus, if you're a validator, most likely you want to read [the orchestrator documentation](https://docs.celestia.org/nodes/blobstream-orchestrator/).
+Also, while every validator in the Celestia validator set needs to run an orchestrator, we only need one entity to run the relayer, and it can be anyone. Thus, if you're a validator, most likely you want to read [the orchestrator documentation](https://docs.celestia.org/nodes/blobstream-orchestrator).
 
-Every relayer needs to target a Blobstream smart contract. This latter can be deployed, if not already, using the `blobstream deploy` command. More details in the [Deploy the Blobstream contract guide](https://docs.celestia.org/nodes/blobstream-deploy/).
+Every relayer needs to target a Blobstream smart contract. This latter can be deployed, if not already, using the `blobstream deploy` command. More details in the [Deploy the Blobstream contract guide](https://docs.celestia.org/nodes/blobstream-deploy).
 
 ## How it works
 

--- a/docs/relayer.md
+++ b/docs/relayer.md
@@ -44,7 +44,7 @@ Make sure to have the Blobstream binary installed. Check out the [Install the Bl
 
 Before starting the relayer, we will need to init the store:
 
-```ssh
+```sh
 blobstream relayer init
 ```
 
@@ -67,7 +67,7 @@ The P2P private key is optional, and a new one will be generated automatically o
 
 The `keys` command will help you set up these keys:
 
-```ssh
+```sh
 blobstream relayer keys  --help
 ```
 
@@ -79,7 +79,7 @@ Because EVM keys are important, we provide a keystore that will help manage them
 
 To import your EVM private key, there is the `import` subcommand to assist you with that:
 
-```ssh
+```sh
 blobstream relayer keys evm import --help
 ```
 
@@ -87,7 +87,7 @@ This subcommand allows you to either import a raw ECDSA private key provided as 
 
 After adding the key, you can check that it's added via running:
 
-```ssh
+```sh
 blobstream relayer keys evm list
 ```
 
@@ -99,7 +99,7 @@ Now that we have the store initialized, and we have a target Blobstream smart co
 
 The relayer accepts the following flags:
 
-```ssh
+```sh
 blobstream relayer start --help
 
 Runs the Blobstream relayer to submit attestations to the target EVM chain
@@ -110,7 +110,7 @@ Usage:
 
 To start the relayer using the default home directory, run the following:
 
-```ssh
+```sh
 /bin/blobstream relayer start \
   --evm.contract-address=0x27a1F8CE94187E4b043f4D57548EF2348Ed556c7 \
   --core.rpc.host=localhost \

--- a/docs/relayer.md
+++ b/docs/relayer.md
@@ -9,9 +9,9 @@ description: Learn about the Blobstream Relayer.
 
 The role of the relayer is to gather attestations' signatures from the orchestrators, and submit them to a target EVM chain. The attestations are generated within the Blobstream module of the Celestia-app state machine. To learn more about what attestations are, you can refer to [the Blobstream overview](https://github.com/celestiaorg/celestia-app/tree/main/x/blobstream).
 
-Also, while every validator in the Celestia validator set needs to run an orchestrator, we only need one entity to run the relayer, and it can be anyone. Thus, if you're a validator, most likely you want to read [the orchestrator documentation](https://docs.celestia.org/nodes/blobstream-orchestrator).
+Also, while every validator in the Celestia validator set needs to run an orchestrator, we only need one entity to run the relayer, and it can be anyone. Thus, if you're a validator, most likely you want to read [the orchestrator documentation](https://docs.celestia.org/nodes/blobstream-orchestrator/).
 
-Every relayer needs to target a Blobstream smart contract. This latter can be deployed, if not already, using the `blobstream deploy` command. More details in the [Deploy the Blobstream contract guide](https://docs.celestia.org/nodes/blobstream-deploy).
+Every relayer needs to target a Blobstream smart contract. This latter can be deployed, if not already, using the `blobstream deploy` command. More details in the [Deploy the Blobstream contract guide](https://docs.celestia.org/nodes/blobstream-deploy/).
 
 ## How it works
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This PR resolves build errors that occur on the documentation site as a result of no support for ssh syntax highlighting. The solution is to use sh.

Resolves https://github.com/celestiaorg/docs/issues/1171


<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [x] New and updated code has appropriate documentation
- [x] New and updated code has new and/or updated testing
- [x] Required CI checks are passing
- [x] Visual proof for any user facing features like CLI or documentation updates
- [x] Linked issues closed with keywords
