### PR TITLE
feat: support secure grpc connections

### DIFF
--- a/cmd/blobstream/base/config.go
+++ b/cmd/blobstream/base/config.go
@@ -46,6 +46,7 @@ const (
 	FlagBootstrappers    = "p2p.bootstrappers"
 	FlagP2PListenAddress = "p2p.listen-addr"
 	FlagP2PNickname      = "p2p.nickname"
+	FlagGRPCInsecure     = "grpc.insecure"
 )
 
 func AddP2PNicknameFlag(cmd *cobra.Command) {
@@ -58,4 +59,8 @@ func AddP2PListenAddressFlag(cmd *cobra.Command) {
 
 func AddBootstrappersFlag(cmd *cobra.Command) {
 	cmd.Flags().String(FlagBootstrappers, "", "Comma-separated multiaddresses of p2p peers to connect to")
+}
+
+func AddGRPCInsecureFlag(cmd *cobra.Command) {
+	cmd.Flags().Bool(FlagGRPCInsecure, false, "allow gRPC over insecure channels, if not TLS the server must use TLS")
 }

--- a/cmd/blobstream/common/helpers.go
+++ b/cmd/blobstream/common/helpers.go
@@ -24,7 +24,7 @@ import (
 
 // NewTmAndAppQuerier helper function that creates a new TmQuerier and AppQuerier and registers their stop functions in the
 // stopFuncs slice.
-func NewTmAndAppQuerier(logger tmlog.Logger, tendermintRPC string, celesGRPC string) (*rpc.TmQuerier, *rpc.AppQuerier, []func() error, error) {
+func NewTmAndAppQuerier(logger tmlog.Logger, tendermintRPC string, celesGRPC string, grpcInsecure bool) (*rpc.TmQuerier, *rpc.AppQuerier, []func() error, error) {
 	// load app encoding configuration
 	encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
@@ -45,7 +45,7 @@ func NewTmAndAppQuerier(logger tmlog.Logger, tendermintRPC string, celesGRPC str
 
 	// creating the application querier
 	appQuerier := rpc.NewAppQuerier(logger, celesGRPC, encCfg)
-	err = appQuerier.Start()
+	err = appQuerier.Start(grpcInsecure)
 	if err != nil {
 		return nil, nil, stopFuncs, err
 	}

--- a/cmd/blobstream/deploy/cmd.go
+++ b/cmd/blobstream/deploy/cmd.go
@@ -44,7 +44,7 @@ func Command() *cobra.Command {
 			encCfg := encoding.MakeConfig(app.ModuleEncodingRegisters...)
 
 			querier := rpc.NewAppQuerier(logger, config.coreGRPC, encCfg)
-			err = querier.Start()
+			err = querier.Start(config.grpcInsecure)
 			if err != nil {
 				return err
 			}

--- a/cmd/blobstream/deploy/config.go
+++ b/cmd/blobstream/deploy/config.go
@@ -42,7 +42,7 @@ func addDeployFlags(cmd *cobra.Command) *cobra.Command {
 	}
 	cmd.Flags().String(base.FlagHome, homeDir, "The Blobstream deployer home directory")
 	cmd.Flags().String(base.FlagEVMPassphrase, "", "the evm account passphrase (if not specified as a flag, it will be asked interactively)")
-
+	base.AddGRPCInsecureFlag(cmd)
 	return cmd
 }
 
@@ -53,6 +53,7 @@ type deployConfig struct {
 	evmAccAddress    string
 	startingNonce    string
 	evmGasLimit      uint64
+	grpcInsecure     bool
 }
 
 func parseDeployFlags(cmd *cobra.Command) (deployConfig, error) {
@@ -102,6 +103,10 @@ func parseDeployFlags(cmd *cobra.Command) (deployConfig, error) {
 	if err != nil {
 		return deployConfig{}, err
 	}
+	grpcInsecure, err := cmd.Flags().GetBool(base.FlagGRPCInsecure)
+	if err != nil {
+		return deployConfig{}, err
+	}
 
 	return deployConfig{
 		evmAccAddress: evmAccAddr,
@@ -114,5 +119,6 @@ func parseDeployFlags(cmd *cobra.Command) (deployConfig, error) {
 			Home:          homeDir,
 			EVMPassphrase: passphrase,
 		},
+		grpcInsecure: grpcInsecure,
 	}, nil
 }

--- a/cmd/blobstream/orchestrator/cmd.go
+++ b/cmd/blobstream/orchestrator/cmd.go
@@ -57,7 +57,7 @@ func Start() *cobra.Command {
 
 			stopFuncs := make([]func() error, 0)
 
-			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC)
+			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC, config.grpcInsecure)
 			stopFuncs = append(stopFuncs, stops...)
 			if err != nil {
 				return err

--- a/cmd/blobstream/orchestrator/config.go
+++ b/cmd/blobstream/orchestrator/config.go
@@ -37,6 +37,7 @@ func addOrchestratorFlags(cmd *cobra.Command) *cobra.Command {
 	base.AddP2PNicknameFlag(cmd)
 	base.AddP2PListenAddressFlag(cmd)
 	base.AddBootstrappersFlag(cmd)
+	base.AddGRPCInsecureFlag(cmd)
 	return cmd
 }
 
@@ -46,6 +47,7 @@ type StartConfig struct {
 	evmAccAddress                string
 	bootstrappers, p2pListenAddr string
 	p2pNickname                  string
+	grpcInsecure                 bool
 }
 
 func parseOrchestratorFlags(cmd *cobra.Command) (StartConfig, error) {
@@ -99,6 +101,10 @@ func parseOrchestratorFlags(cmd *cobra.Command) (StartConfig, error) {
 	if err != nil {
 		return StartConfig{}, err
 	}
+	grpcInsecure, err := cmd.Flags().GetBool(base.FlagGRPCInsecure)
+	if err != nil {
+		return StartConfig{}, err
+	}
 
 	return StartConfig{
 		evmAccAddress: evmAccAddr,
@@ -111,6 +117,7 @@ func parseOrchestratorFlags(cmd *cobra.Command) (StartConfig, error) {
 			Home:          homeDir,
 			EVMPassphrase: passphrase,
 		},
+		grpcInsecure: grpcInsecure,
 	}, nil
 }
 

--- a/cmd/blobstream/query/cmd.go
+++ b/cmd/blobstream/query/cmd.go
@@ -75,7 +75,7 @@ func Signers() *cobra.Command {
 			}()
 
 			// create tm querier and app querier
-			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC)
+			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC, config.grpcInsecure)
 			stopFuncs = append(stopFuncs, stops...)
 			if err != nil {
 				return err
@@ -358,7 +358,7 @@ func Signature() *cobra.Command {
 			}()
 
 			// create tm querier and app querier
-			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC)
+			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC, config.grpcInsecure)
 			stopFuncs = append(stopFuncs, stops...)
 			if err != nil {
 				return err

--- a/cmd/blobstream/query/config.go
+++ b/cmd/blobstream/query/config.go
@@ -3,6 +3,8 @@ package query
 import (
 	"fmt"
 
+	"github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/base"
+
 	"github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/relayer"
 	"github.com/spf13/cobra"
 )
@@ -19,6 +21,7 @@ func addFlags(cmd *cobra.Command) *cobra.Command {
 	cmd.Flags().Uint(relayer.FlagCoreRPCPort, 26657, "Specify the rest rpc address")
 	cmd.Flags().String(FlagP2PNode, "", "P2P target node multiaddress (eg. /ip4/127.0.0.1/tcp/30000/p2p/12D3KooWBSMasWzRSRKXREhediFUwABNZwzJbkZcYz5rYr9Zdmfn)")
 	cmd.Flags().String(FlagOutputFile, "", "Path to an output file path if the results need to be written to a json file. Leaving it as empty will result in printing the result to stdout")
+	base.AddGRPCInsecureFlag(cmd)
 
 	return cmd
 }
@@ -27,6 +30,7 @@ type Config struct {
 	coreGRPC, coreRPC string
 	targetNode        string
 	outputFile        string
+	grpcInsecure      bool
 }
 
 func parseFlags(cmd *cobra.Command) (Config, error) {
@@ -54,11 +58,15 @@ func parseFlags(cmd *cobra.Command) (Config, error) {
 	if err != nil {
 		return Config{}, err
 	}
-
+	grpcInsecure, err := cmd.Flags().GetBool(base.FlagGRPCInsecure)
+	if err != nil {
+		return Config{}, err
+	}
 	return Config{
-		coreGRPC:   fmt.Sprintf("%s:%d", coreGRPCHost, coreGRPCPort),
-		coreRPC:    fmt.Sprintf("tcp://%s:%d", coreRPCHost, coreRPCPort),
-		targetNode: targetNode,
-		outputFile: outputFile,
+		coreGRPC:     fmt.Sprintf("%s:%d", coreGRPCHost, coreGRPCPort),
+		coreRPC:      fmt.Sprintf("tcp://%s:%d", coreRPCHost, coreRPCPort),
+		targetNode:   targetNode,
+		outputFile:   outputFile,
+		grpcInsecure: grpcInsecure,
 	}, nil
 }

--- a/cmd/blobstream/relayer/cmd.go
+++ b/cmd/blobstream/relayer/cmd.go
@@ -97,7 +97,7 @@ func Start() *cobra.Command {
 
 			stopFuncs := make([]func() error, 0)
 
-			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC)
+			tmQuerier, appQuerier, stops, err := common.NewTmAndAppQuerier(logger, config.coreRPC, config.coreGRPC, config.grpcInsecure)
 			stopFuncs = append(stopFuncs, stops...)
 			if err != nil {
 				return err

--- a/cmd/blobstream/relayer/config.go
+++ b/cmd/blobstream/relayer/config.go
@@ -46,6 +46,7 @@ func addRelayerStartFlags(cmd *cobra.Command) *cobra.Command {
 	base.AddP2PNicknameFlag(cmd)
 	base.AddP2PListenAddressFlag(cmd)
 	base.AddBootstrappersFlag(cmd)
+	base.AddGRPCInsecureFlag(cmd)
 
 	return cmd
 }
@@ -59,6 +60,7 @@ type StartConfig struct {
 	evmGasLimit                  uint64
 	bootstrappers, p2pListenAddr string
 	p2pNickname                  string
+	grpcInsecure                 bool
 }
 
 func parseRelayerStartFlags(cmd *cobra.Command) (StartConfig, error) {
@@ -135,6 +137,10 @@ func parseRelayerStartFlags(cmd *cobra.Command) (StartConfig, error) {
 	if err != nil {
 		return StartConfig{}, err
 	}
+	grpcInsecure, err := cmd.Flags().GetBool(base.FlagGRPCInsecure)
+	if err != nil {
+		return StartConfig{}, err
+	}
 
 	return StartConfig{
 		evmAccAddress: evmAccAddr,
@@ -151,6 +157,7 @@ func parseRelayerStartFlags(cmd *cobra.Command) (StartConfig, error) {
 			Home:          homeDir,
 			EVMPassphrase: passphrase,
 		},
+		grpcInsecure: grpcInsecure,
 	}, nil
 }
 

--- a/e2e/qgb_network.go
+++ b/e2e/qgb_network.go
@@ -420,7 +420,7 @@ func (network BlobstreamNetwork) WaitForOrchestratorToStart(_ctx context.Context
 	p2pQuerier := p2p.NewQuerier(dht, network.Logger)
 
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err := appQuerier.Start()
+	err := appQuerier.Start(true)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -491,7 +491,7 @@ func (network BlobstreamNetwork) WaitForOrchestratorToStart(_ctx context.Context
 // Thus, any nonce after the returned valset should be signed by all orchestrators.
 func (network BlobstreamNetwork) GetValsetContainingVals(_ctx context.Context, number int) (*types.Valset, error) {
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err := appQuerier.Start()
+	err := appQuerier.Start(true)
 	if err != nil {
 		return nil, err
 	}
@@ -539,7 +539,7 @@ func (network BlobstreamNetwork) GetValsetConfirm(
 	p2pQuerier := p2p.NewQuerier(dht, network.Logger)
 	// create app querier
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err := appQuerier.Start()
+	err := appQuerier.Start(true)
 	if err != nil {
 		return nil, err
 	}
@@ -602,7 +602,7 @@ func (network BlobstreamNetwork) GetDataCommitmentConfirm(
 
 	// create app querier
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err = appQuerier.Start()
+	err = appQuerier.Start(true)
 	if err != nil {
 		return nil, err
 	}
@@ -651,7 +651,7 @@ func (network BlobstreamNetwork) GetDataCommitmentConfirmByHeight(
 ) (*blobstreamtypes.DataCommitmentConfirm, error) {
 	// create app querier
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err := appQuerier.Start()
+	err := appQuerier.Start(true)
 	if err != nil {
 		return nil, err
 	}
@@ -672,7 +672,7 @@ func (network BlobstreamNetwork) GetDataCommitmentConfirmByHeight(
 func (network BlobstreamNetwork) GetLatestAttestationNonce(_ctx context.Context) (uint64, error) {
 	// create app querier
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err := appQuerier.Start()
+	err := appQuerier.Start(true)
 	if err != nil {
 		return 0, err
 	}
@@ -694,7 +694,7 @@ func (network BlobstreamNetwork) WasAttestationSigned(
 ) (bool, error) {
 	// create app querier
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err := appQuerier.Start()
+	err := appQuerier.Start(true)
 	if err != nil {
 		return false, err
 	}
@@ -992,7 +992,7 @@ func (network BlobstreamNetwork) PrintLogs() {
 func (network BlobstreamNetwork) GetLatestValset(ctx context.Context) (*types.Valset, error) {
 	// create app querier
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
-	err := appQuerier.Start()
+	err := appQuerier.Start(true)
 	if err != nil {
 		return nil, err
 	}

--- a/e2e/relayer_test.go
+++ b/e2e/relayer_test.go
@@ -183,7 +183,7 @@ func TestRelayerWithMultipleValidators(t *testing.T) {
 	// check whether the four validators are up and running
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
 	HandleNetworkError(t, network, err, false)
-	err = appQuerier.Start()
+	err = appQuerier.Start(true)
 	HandleNetworkError(t, network, err, false)
 	defer appQuerier.Stop() //nolint:errcheck
 
@@ -270,7 +270,7 @@ func TestUpdatingTheDataCommitmentWindow(t *testing.T) {
 	// check whether the four validators are up and running
 	appQuerier := rpc.NewAppQuerier(network.Logger, network.CelestiaGRPC, network.EncCfg)
 	HandleNetworkError(t, network, err, false)
-	err = appQuerier.Start()
+	err = appQuerier.Start(true)
 	HandleNetworkError(t, network, err, false)
 	defer appQuerier.Stop() //nolint:errcheck
 

--- a/e2e/scripts/deploy_blobstream_contract.sh
+++ b/e2e/scripts/deploy_blobstream_contract.sh
@@ -68,6 +68,7 @@ echo "deploying Blobstream contract..."
   --evm.account "${EVM_ACCOUNT}" \
   --core.grpc.host "${CORE_GRPC_HOST}" \
   --core.grpc.port "${CORE_GRPC_PORT}" \
+  --grpc.insecure \
   --starting-nonce "${STARTING_NONCE}" \
   --evm.rpc "${EVM_ENDPOINT}" \
   --evm.passphrase=123 > /opt/output

--- a/e2e/scripts/start_orchestrator_after_validator_created.sh
+++ b/e2e/scripts/start_orchestrator_after_validator_created.sh
@@ -53,6 +53,7 @@ then
     --core.rpc.port="${CORE_RPC_PORT}" \
     --core.grpc.host="${CORE_GRPC_HOST}" \
     --core.grpc.port="${CORE_GRPC_PORT}" \
+    --grpc.insecure \
     --p2p.nickname=key \
     --p2p.listen-addr="${P2P_LISTEN}" \
     --evm.passphrase=123

--- a/e2e/scripts/start_orchestrator_after_validator_created.sh
+++ b/e2e/scripts/start_orchestrator_after_validator_created.sh
@@ -67,6 +67,7 @@ else
     --core.rpc.port="${CORE_RPC_PORT}" \
     --core.grpc.host="${CORE_GRPC_HOST}" \
     --core.grpc.port="${CORE_GRPC_PORT}" \
+    --grpc.insecure \
     --p2p.listen-addr="${P2P_LISTEN}" \
     --p2p.bootstrappers="${P2P_BOOTSTRAPPERS}" \
     --evm.passphrase=123

--- a/e2e/scripts/start_relayer.sh
+++ b/e2e/scripts/start_relayer.sh
@@ -59,6 +59,7 @@ sleep 5s
   --core.rpc.port="${CORE_RPC_PORT}" \
   --core.grpc.host="${CORE_GRPC_HOST}" \
   --core.grpc.port="${CORE_GRPC_PORT}" \
+  --grpc.insecure \
   --evm.chain-id="${EVM_CHAIN_ID}" \
   --evm.rpc="${EVM_ENDPOINT}" \
   --evm.contract-address="${BLOBSTREAM_CONTRACT}" \

--- a/orchestrator/orchestrator_test.go
+++ b/orchestrator/orchestrator_test.go
@@ -182,7 +182,7 @@ func (s *OrchestratorTestSuite) TestEnqueuingAttestationNonces() {
 		s.Node.CelestiaNetwork.GRPCAddr,
 		ecfg,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	latestNonce, err := appQuerier.QueryLatestAttestationNonce(ctx)

--- a/rpc/app_querier_test.go
+++ b/rpc/app_querier_test.go
@@ -14,7 +14,7 @@ func (s *QuerierTestSuite) TestQueryAttestationByNonce() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	att, err := appQuerier.QueryAttestationByNonce(context.Background(), 1)
@@ -28,7 +28,7 @@ func (s *QuerierTestSuite) TestQueryLatestAttestationNonce() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	nonce, err := appQuerier.QueryLatestAttestationNonce(context.Background())
@@ -42,7 +42,7 @@ func (s *QuerierTestSuite) TestQueryDataCommitmentByNonce() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	dc, err := appQuerier.QueryDataCommitmentByNonce(context.Background(), 2)
@@ -56,7 +56,7 @@ func (s *QuerierTestSuite) TestQueryDataCommitmentForHeight() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	dc, err := appQuerier.QueryDataCommitmentForHeight(context.Background(), 10)
@@ -70,7 +70,7 @@ func (s *QuerierTestSuite) TestQueryValsetByNonce() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	vs, err := appQuerier.QueryValsetByNonce(context.Background(), 1)
@@ -84,7 +84,7 @@ func (s *QuerierTestSuite) TestQueryLatestValset() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	vs, err := appQuerier.QueryLatestValset(context.Background())
@@ -98,7 +98,7 @@ func (s *QuerierTestSuite) TestQueryLastValsetBeforeNonce() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	vs, err := appQuerier.QueryLastValsetBeforeNonce(context.Background(), 2)
@@ -112,7 +112,7 @@ func (s *QuerierTestSuite) TestQueryLastUnbondingHeight() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	unbondingHeight, err := appQuerier.QueryLastUnbondingHeight(context.Background())
@@ -126,7 +126,7 @@ func (s *QuerierTestSuite) TestQueryEarliestAttestationNonce() {
 		s.Network.GRPCAddr,
 		s.EncConf,
 	)
-	require.NoError(s.T(), appQuerier.Start())
+	require.NoError(s.T(), appQuerier.Start(true))
 	defer appQuerier.Stop() //nolint:errcheck
 
 	earliestNonce, err := appQuerier.QueryEarliestAttestationNonce(context.Background())

--- a/testing/qgb.go
+++ b/testing/qgb.go
@@ -32,7 +32,7 @@ func NewRelayer(
 	logger := tmlog.NewNopLogger()
 	node.CelestiaNetwork.GRPCClient.Close()
 	appQuerier := rpc.NewAppQuerier(logger, node.CelestiaNetwork.GRPCAddr, encoding.MakeConfig(app.ModuleEncodingRegisters...))
-	require.NoError(t, appQuerier.Start())
+	require.NoError(t, appQuerier.Start(true))
 	t.Cleanup(func() {
 		_ = appQuerier.Stop()
 	})
@@ -66,7 +66,7 @@ func NewOrchestrator(
 ) *orchestrator.Orchestrator {
 	logger := tmlog.NewNopLogger()
 	appQuerier := rpc.NewAppQuerier(logger, node.CelestiaNetwork.GRPCAddr, encoding.MakeConfig(app.ModuleEncodingRegisters...))
-	require.NoError(t, appQuerier.Start())
+	require.NoError(t, appQuerier.Start(true))
 	t.Cleanup(func() {
 		_ = appQuerier.Stop()
 	})


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Closes https://github.com/celestiaorg/orchestrator-relayer/issues/352

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a new `--grpc-insecure` flag to enable gRPC communication over insecure channels.

- **Bug Fixes**
  - Adjusted function calls to accommodate the new `grpcInsecure` parameter, ensuring correct behavior based on the user's preference for secure or insecure gRPC connections.

- **Tests**
  - Updated test cases to reflect the new `grpcInsecure` parameter in function calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->