### PR TITLE
chore: dependabot for e2e

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
       - dependencies
     reviewers: 
       - "sweexordious"
-  - package-ecosystem: gomod e2e
+  - package-ecosystem: gomod
     directory: "e2e"
     schedule:
       interval: daily


### PR DESCRIPTION
Closes https://github.com/celestiaorg/orchestrator-relayer/issues/595

`gomod e2e` isn't a valid package ecosystem. The valid package ecosystems are listed [here](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem). I think it should just be `gomod`.

I haven't tested this yet but it seems safe to just ship it and observe dependabot PRs in this repo after it merges.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated dependency management settings to focus on the main module ecosystem.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->