### PR TITLE
chore: `.PHONY` targets for Make commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,26 +6,32 @@ versioningPath := "github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/ve
 LDFLAGS=-ldflags="-X '$(versioningPath).buildTime=$(shell date)' -X '$(versioningPath).lastCommit=$(shell git rev-parse HEAD)' -X '$(versioningPath).semanticVersion=$(shell git describe --tags --dirty=-dev 2>/dev/null || git rev-parse --abbrev-ref HEAD)'"
 
 all: install
+.PHONY: all
 
-install: go.sum
+install: mod-verify
 	@echo "--> Installing blobstream"
 	@go install -mod=readonly ${LDFLAGS} ./cmd/blobstream
+.PHONY: install
 
-go.sum: mod
+mod-verify: mod
 	@echo "--> Verifying dependencies have expected content"
 	GO111MODULE=on go mod verify
+.PHONY: mod-verify
 
 mod:
 	@echo "--> Updating go.mod"
 	@go mod tidy
+.PHONY: mod
 
 pre-build:
 	@echo "--> Fetching latest git tags"
 	@git fetch --tags
+.PHONY: pre-build
 
 build: mod
 	@mkdir -p build/
 	@go build -o build ${LDFLAGS} ./cmd/blobstream
+.PHONY: build
 
 build-docker:
 	@echo "--> Building Docker image"
@@ -52,6 +58,7 @@ test:
 .PHONY: test
 
 test-all: test-race test-cover
+.PHONY: test-all
 
 test-race:
 	@echo "--> Running tests with -race"


### PR DESCRIPTION
Add `.PHONY` targets for all Make commands. In a Makefile, the `.PHONY` target is used to specify that certain targets are 'phony' and not file names.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the Makefile to improve the build process with new targets for installation, dependency verification, pre-build actions, and comprehensive testing.
- **Refactor**
  - Streamlined dependency checks by replacing the previous method with a `mod-verify` target.
- **New Features**
  - Introduced a `pre-build` step to automatically fetch the latest git tags before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->