### PR TITLE
docs: update README to specify that a relayer can be run to an existing contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ If you are a Celestia-app validator, all you need to do is run the orchestrator.
 
 If you want to post commitments on an EVM chain, you will need to deploy a new Blobstream contract and run a relayer. Check [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/relayer.md) for relayer docs and [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/deploy.md) for how to deploy a new Blobstream contract.
 
+If you want to post commitments on an EVM chain, you will need to deploy a new Blobstream contract and run a relayer, or run a relayer to an already deployed Blobstream contract. Check [relayer docs](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/relayer.md) and [deployment docs](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/deploy.md) for more information.
+
 Note: the Blobstream P2P network is a separate network from the consensus or the data availability one. Thus, you will need its specific bootstrappers to be able to connect to it.
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ blobstream --help
 
 If you are a Celestia-app validator, all you need to do is run the orchestrator. Check [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/orchestrator.md) for more details.
 
-If you want to post commitments on an EVM chain, you will need to deploy a new Blobstream contract and run a relayer. Check [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/relayer.md) for relayer docs and [here](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/deploy.md) for how to deploy a new Blobstream contract.
-
 If you want to post commitments on an EVM chain, you will need to deploy a new Blobstream contract and run a relayer, or run a relayer to an already deployed Blobstream contract. Check [relayer docs](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/relayer.md) and [deployment docs](https://github.com/celestiaorg/orchestrator-relayer/blob/main/docs/deploy.md) for more information.
 
 Note: the Blobstream P2P network is a separate network from the consensus or the data availability one. Thus, you will need its specific bootstrappers to be able to connect to it.


### PR DESCRIPTION

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

Closes https://github.com/celestiaorg/orchestrator-relayer/issues/599

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Updated the README with alternative options for posting commitments on an EVM chain, including running a relayer to an existing Blobstream contract.
	- Reorganized and updated links to relayer and deployment documentation for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->