### PR TITLE
feat: relayer adjusting gas price per transaction

### DIFF
--- a/benchmark/main.go
+++ b/benchmark/main.go
@@ -92,7 +92,7 @@ func DeployContractAndSubmitDataCommitment() error {
 		return err
 	}
 
-	backend, err := evmClient.NewEthClient()
+	backend, err := evmClient.GetEthClient()
 	if err != nil {
 		return err
 	}

--- a/cmd/blobstream/deploy/cmd.go
+++ b/cmd/blobstream/deploy/cmd.go
@@ -126,7 +126,7 @@ func Command() *cobra.Command {
 				return err
 			}
 
-			backend, err := evmClient.NewEthClient()
+			backend, err := evmClient.GetEthClient()
 			if err != nil {
 				return err
 			}

--- a/evm/evm_client.go
+++ b/evm/evm_client.go
@@ -23,12 +23,13 @@ import (
 const DefaultEVMGasLimit = uint64(2500000)
 
 type Client struct {
-	logger   tmlog.Logger
-	Wrapper  *blobstreamwrapper.Wrappers
-	Ks       *keystore.KeyStore
-	Acc      *accounts.Account
-	EvmRPC   string
-	GasLimit uint64
+	logger    tmlog.Logger
+	Wrapper   *blobstreamwrapper.Wrappers
+	Ks        *keystore.KeyStore
+	Acc       *accounts.Account
+	EvmRPC    string
+	GasLimit  uint64
+	EthClient *ethclient.Client
 }
 
 // NewClient Creates a new EVM Client that can be used to deploy the Blobstream contract and
@@ -52,13 +53,16 @@ func NewClient(
 	}
 }
 
-// NewEthClient creates a new Eth client using the existing EVM RPC address.
-// Should be closed after usage.
-func (ec *Client) NewEthClient() (*ethclient.Client, error) {
+// GetEthClient creates a new Eth client using the existing EVM RPC address or returns the existing one.
+func (ec *Client) GetEthClient() (*ethclient.Client, error) {
+	if ec.EthClient != nil {
+		return ec.EthClient, nil
+	}
 	ethClient, err := ethclient.Dial(ec.EvmRPC)
 	if err != nil {
 		return nil, err
 	}
+	ec.EthClient = ethClient
 	return ethClient, nil
 }
 

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -61,7 +61,7 @@ func NewRelayer(
 }
 
 func (r *Relayer) Start(ctx context.Context) error {
-	ethClient, err := r.EVMClient.NewEthClient()
+	ethClient, err := r.EVMClient.GetEthClient()
 	if err != nil {
 		r.logger.Error(err.Error())
 		return err
@@ -160,6 +160,12 @@ func (r *Relayer) ProcessAttestation(ctx context.Context, opts *bind.TransactOpt
 		}
 		r.logger.Debug("found the needed valset")
 	}
+	// set new gas price in case it changed
+	bigGasPrice, err := r.EVMClient.EthClient.SuggestGasPrice(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Ethereum gas estimate: %w", err)
+	}
+	opts.GasPrice = bigGasPrice
 	switch att := attI.(type) {
 	case *celestiatypes.Valset:
 		signBytes, err := att.SignBytes()


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

This allows the relayer to get the gas price before every transaction. This would help the relayer stay up to date and not submit transactions that have a very low gas price and take an eternity to be picked up.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords
