### PR TITLE
chore: log the version when starting orchestrator and relayer

### DIFF
--- a/cmd/blobstream/orchestrator/cmd.go
+++ b/cmd/blobstream/orchestrator/cmd.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/version"
+
 	"github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/base"
 
 	"github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/common"
@@ -66,7 +68,8 @@ func Start() *cobra.Command {
 				return err
 			}
 
-			logger.Info("initializing orchestrator", "home", homeDir)
+			buildInfo := version.GetBuildInfo()
+			logger.Info("initializing orchestrator", "home", homeDir, "version", buildInfo.SemanticVersion, "build_date", buildInfo.BuildTime)
 
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()

--- a/cmd/blobstream/relayer/cmd.go
+++ b/cmd/blobstream/relayer/cmd.go
@@ -5,6 +5,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/version"
+
 	"github.com/celestiaorg/orchestrator-relayer/cmd/blobstream/base"
 
 	ethcmn "github.com/ethereum/go-ethereum/common"
@@ -119,7 +121,9 @@ func Start() *cobra.Command {
 				return err
 			}
 
-			logger.Info("initializing relayer", "home", homeDir)
+			buildInfo := version.GetBuildInfo()
+			logger.Info("initializing relayer", "home", homeDir, "version", buildInfo.SemanticVersion, "build_date", buildInfo.BuildTime)
+
 			ctx, cancel := context.WithCancel(cmd.Context())
 			defer cancel()
 


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

<!-- 
Please provide an explanation of the PR, including the appropriate context,
background, goal, and rationale. If there is an issue with this information,
please provide a tl;dr and link the issue. 
-->

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The app now logs build information upon initialization for both the orchestrator and the relayer components, enhancing transparency on the current version in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->