### PR TITLE
feat: speed up transactions if they don't get included initially

### DIFF
--- a/evm/evm_client.go
+++ b/evm/evm_client.go
@@ -3,10 +3,11 @@ package evm
 import (
 	"context"
 	"errors"
-	"github.com/ethereum/go-ethereum/accounts"
-	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"math/big"
 	"time"
+
+	"github.com/ethereum/go-ethereum/accounts"
+	"github.com/ethereum/go-ethereum/accounts/keystore"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	coregethtypes "github.com/ethereum/go-ethereum/core/types"

--- a/evm/evm_client.go
+++ b/evm/evm_client.go
@@ -3,11 +3,10 @@ package evm
 import (
 	"context"
 	"errors"
-	"math/big"
-	"time"
-
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
+	"math/big"
+	"time"
 
 	gethcommon "github.com/ethereum/go-ethereum/common"
 	coregethtypes "github.com/ethereum/go-ethereum/core/types"
@@ -241,7 +240,6 @@ func (ec *Client) WaitForTransaction(
 		ec.logger.Info("transaction confirmed", "hash", tx.Hash().String(), "block", receipt.BlockNumber.Uint64())
 		return receipt, nil
 	}
-	ec.logger.Error("transaction failed", "hash", tx.Hash().String())
 
 	return receipt, err
 }

--- a/relayer/errors.go
+++ b/relayer/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrAttestationNotDataCommitmentRequest = errors.New("attestation is not a data commitment request")
 	ErrAttestationNotFound                 = errors.New("attestation not found")
 	ErrValidatorSetMismatch                = errors.New("p2p validator set is different from the trusted contract one")
+	ErrTransactionStillPending             = errors.New("evm transaction still pending")
 )

--- a/relayer/relayer.go
+++ b/relayer/relayer.go
@@ -392,7 +392,7 @@ func (r *Relayer) waitForTransactionAndRetryIfNeeded(ctx context.Context, ethCli
 				newTx.GasPrice = newGasPrice
 				newTx2 := coregethtypes.NewTx(newTx)
 				err = ethClient.SendTransaction(ctx, newTx2)
-				r.logger.Debug("submitted speed up transaction", "hash", newTx2.Hash().Hex(), "new_gas_price", newTx2.GasPrice().Uint64())
+				r.logger.Info("submitted speed up transaction", "hash", newTx2.Hash().Hex(), "new_gas_price", newTx2.GasPrice().Uint64())
 				if err != nil {
 					r.logger.Debug("response of sending speed up transaction", "resp", err.Error())
 				}


### PR DESCRIPTION
<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Re-queries the gas price from the network in case the transaction doesn't get including during the provided timeout and resends it with it.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new error notification for pending transactions to enhance user awareness.
  - Implemented improved transaction waiting logic with retry capabilities for better reliability.

- **Refactor**
  - Optimized transaction processing flow for efficiency and user experience.

- **Documentation**
  - Updated error documentation to reflect new error handling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->