### PR TITLE
feat: support querying the number of orchestrator signatures for a nonces range

### DIFF
--- a/cmd/blobstream/query/cmd.go
+++ b/cmd/blobstream/query/cmd.go
@@ -257,15 +257,16 @@ func SignersRange() *cobra.Command {
 						}]++
 					} else {
 						// keep the same number of signatures the same but still have the value in the map
-						signersMap[validatorInfo{
-							EvmAddress:   sig.EvmAddress,
-							Moniker:      sig.Moniker,
-							ValopAddress: sig.ValopAddress,
-						}] = signersMap[validatorInfo{
+						val := signersMap[validatorInfo{
 							EvmAddress:   sig.EvmAddress,
 							Moniker:      sig.Moniker,
 							ValopAddress: sig.ValopAddress,
 						}]
+						signersMap[validatorInfo{
+							EvmAddress:   sig.EvmAddress,
+							Moniker:      sig.Moniker,
+							ValopAddress: sig.ValopAddress,
+						}] = val
 					}
 				}
 			}


### PR DESCRIPTION
…nces range

<!--
Please read and fill out this form before submitting your PR.

Please make sure you have reviewed our contributors guide before submitting your
first PR.
-->

## Overview

Closes https://github.com/celestiaorg/orchestrator-relayer/issues/629

Example output:

```
D[2023-12-03|03:28:00.072] initializing queriers                        
D[2023-12-03|03:28:00.154] connecting to target node...                 
D[2023-12-03|03:28:00.332] connected to target node                     
I[2023-12-03|03:28:00.332] getting signatures for nonce                 nonce=1834
I[2023-12-03|03:33:07.133] getting signatures for nonce                 nonce=1835
I[2023-12-03|03:34:59.423] Conqueror                                    evm_address=0xeCB849d5F0AaD91c2d5e3b052410E491B4d14999 valop_address=celestiavaloper17vmk8m246t648hpmde2q7kp4ft9uwrayy09dmw number_of_signatures=2
I[2023-12-03|03:34:59.424] Validatrium                                  evm_address=0x72E1f9D458B648f6A8EABF96B2a7E9EaFdCb54d3 valop_address=celestiavaloper1lu29du5nnh9j7t0dg2td0jcmqnd8uy6kjnls76 number_of_signatures=2
I[2023-12-03|03:34:59.424] Blockscope.net                               evm_address=0x16985307B2B50cA890429c67956705C0b6e0cceE valop_address=celestiavaloper1lpau2hsr40pk6k9luw8mjknq4luv7jc82hw8uf number_of_signatures=0
I[2023-12-03|03:34:59.424] node-spinter                                 evm_address=0xEC51A0b9803a9b6691Ad33A866F120bB2B03c513 valop_address=celestiavaloper1a3g6pwvq82dkdyddxw5xdufqhv4s83gn6lgxmd number_of_signatures=0
I[2023-12-03|03:34:59.424] counterpoint                                 evm_address=0xDbAACD916aE965165d2b95e2EB7A8148666eC640 valop_address=celestiavaloper1q4dum94p9xcp4kg4xcdphr3f69uycw7szxppl7 number_of_signatures=2
I[2023-12-03|03:34:59.424] Node Guardians                               evm_address=0x07362708409Cc20634762aAA4086CC2b5373C187 valop_address=celestiavaloper1fg9l3xvfuu9wxremv2229966zawysg4r40gw5x number_of_signatures=2
I[2023-12-03|03:34:59.424] ZKValidator                                  evm_address=0x429c647C66e86C4150eD005d5c85B77BE8a26F1D valop_address=celestiavaloper14w4l6qvq5z5l2fkjl4ksfth8xtfraxa5ukudkl number_of_signatures=2
I[2023-12-03|03:34:59.424] Cosmostation                                 evm_address=0x243855E1f8570a89AeCD830EBe6f52ea38274d3c valop_address=celestiavaloper1x5wgh6vwye60wv3dtshs9dmqggwfx2ld84lsqy number_of_signatures=2
I[2023-12-03|03:34:59.424] [NODERS]TEAM                                 evm_address=0x7d0f205f4a7F10B7B1c6282193aA202dC16fBbbe valop_address=celestiavaloper1zzxrq7tjlsqvv0jtqtlt8gjaa68racukf5n9xh number_of_signatures=2
I[2023-12-03|03:34:59.424] Kalia Network                                evm_address=0xeCc578a414c77472F0531837213Ae10DC78634fC valop_address=celestiavaloper1anzh3fq5ca689uznrqmjzwhpphrcvd8u58enel number_of_signatures=0
I[2023-12-03|03:34:59.424] Architect Nodes                              evm_address=0x65E1397ddbC7494d6B802567fa9A22B1a1E63618 valop_address=celestiavaloper1vhsnjlwmcay566uqy4nl4x3zkxs7vdscwyk6cd number_of_signatures=0
I[2023-12-03|03:34:59.424] Qubelabs                                     evm_address=0xDE75eaD0d74aDd4cA42761C5BA27BC7477fd68F5 valop_address=celestiavaloper1hvp2nfz3r6nqt8mlrzqf9ctwle942tkr23zxgj number_of_signatures=2
I[2023-12-03|03:34:59.424] B-Harvest                                    evm_address=0xBeE0b6b8c1589803a7C1a13764D89C3aa77A3CAD valop_address=celestiavaloper1jwa2ests89vq89qrtztl60q2c8ygtj30wl2a7l number_of_signatures=2
I[2023-12-03|03:34:59.424] hextrust                                     evm_address=0x45412470Edc166D2118547De01E37249c6d5A7A1 valop_address=celestiavaloper1ukk0l6ce58zq3snad5vn24vy7pdk9r8hva6nz9 number_of_signatures=2
I[2023-12-03|03:34:59.424] 0base.vc                                     evm_address=0x56358735f607D153C1b794e654Bc47521f83a93b valop_address=celestiavaloper12c6cwd0kqlg48sdhjnn9f0z82g0c82fmrl7j9y number_of_signatures=0
I[2023-12-03|03:34:59.424] Coinbase Cloud 2                             evm_address=0x311663C98e094186B7c292e12281a96CE58Ed039 valop_address=celestiavaloper107pdw6ysyg0fvfp4cj2gcel0wdpr4ddd7cjj05 number_of_signatures=0
I[2023-12-03|03:34:59.425] AM Solutions 🪐                               evm_address=0xCD898b97CB74171D85707522E1C036e1ac640A71 valop_address=celestiavaloper1qt7tfh9ye2yhc5jr5lx6su752zfjxv4jtunxsp number_of_signatures=2
I[2023-12-03|03:34:59.425] Suntzu                                       evm_address=0xD96d4B52CAb35cF3DF1d58765bD2eA7cb1Fb6016 valop_address=celestiavaloper13qtjn9auxv68humrv9s0673yw6cqas09vj6wfv number_of_signatures=2
I[2023-12-03|03:34:59.425] Staking4All                                  evm_address=0xA85d6C4bca306259e82060F18AE9f0A48aA7e6F4 valop_address=celestiavaloper1amm0umxqxxw8j2q60x78xs32s089606sdmvx92 number_of_signatures=2
I[2023-12-03|03:34:59.425] BwareLabs                                    evm_address=0x52Ae4dD4A1C085a5D0a82eb8dd136a78c746C57e valop_address=celestiavaloper15e9k43hy3gd6d0z6u25evqq9yzpv5cyrx0gjz7 number_of_signatures=2
I[2023-12-03|03:34:59.425] RockawayX Infra                              evm_address=0x08ccb45d7090dAE6AeCB3aaC4Cc7BE272DBc749a valop_address=celestiavaloper1prxtghtsjrdwdtkt82kye3a7yukmcay6r67aak number_of_signatures=0
I[2023-12-03|03:34:59.425] Donald                                       evm_address=0x0988f6f4cfDa48e2a05A09B47302F1712969fd66 valop_address=celestiavaloper1ad3p8383vwz33jezkr99kj2dlxa4erwexev2ka number_of_signatures=2
I[2023-12-03|03:34:59.425] Zhrand                                       evm_address=0xD6E25E7A5FF227Fa3c921b055A346A3214a4A3E8 valop_address=celestiavaloper188ft08px5hryqxe5hawav4q6jugsnj6usny3la number_of_signatures=2
I[2023-12-03|03:34:59.425] Stake🦑Squid                                  evm_address=0x2Fdb90a3940A5d2D3FfE52839cdB3A9d58918cF0 valop_address=celestiavaloper13u434q3dnzq0hzl4knpxsgg65gd43aadr99u6d number_of_signatures=2
I[2023-12-03|03:34:59.425] Neuler                                       evm_address=0x922303E8AceeF3f7553435266Db600ca85b7E3B8 valop_address=celestiavaloper1c58x4mfphqz8lvfwvjr75sdcqlx3s92cae4f7l number_of_signatures=2
I[2023-12-03|03:34:59.425] Enigma                                       evm_address=0x24D5816253c13EB212CF0A13A0297ec7b2C7a3BE valop_address=celestiavaloper1jw6qaahxd4qw26aelfmrdpxxrnarfjnaruc5g2 number_of_signatures=2
I[2023-12-03|03:34:59.426] danku_zone w/ DAIC                           evm_address=0x28853D64b3D0c2ccD67533D35A7C720F2c95E30e valop_address=celestiavaloper1naw9uqc9vzk40gn6w58u988jy4hqc5la3nvum0 number_of_signatures=0
I[2023-12-03|03:34:59.426] polkachu.com                                 evm_address=0xf9Ea19bbD5a7520De3F61626d3Aac15cB34197d9 valop_address=celestiavaloper1jt9w26mpxxjsk63mvd4m2ynj0af09cslh5d096 number_of_signatures=0
I[2023-12-03|03:34:59.426] Catuai                                       evm_address=0x9B8c3d657AEe2E227C98f694FDd5d5e5e4cccd26 valop_address=celestiavaloper1nwxr6et6achzylyc7620m4w4uhjvenfx0faus3 number_of_signatures=0
I[2023-12-03|03:34:59.426] DAS-MOCHA                                    evm_address=0xA377957F2EED149eEEB1F922f6552444e265ba61 valop_address=celestiavaloper17adsjkuecgjheugrdrwdqv9uh3qkrfmjqeqycq number_of_signatures=2
I[2023-12-03|03:34:59.426] MZONDER                                      evm_address=0xA1a61a1F19ff98186D261C9b579Cd1f1FA2304d4 valop_address=celestiavaloper14s0j44u98rpdnu8sejxykad6xm0px7kf054p6v number_of_signatures=2
I[2023-12-03|03:34:59.426] kooltek68                                    evm_address=0xfa86f61B880C036D0B375Fd8F2150E2994DF4029 valop_address=celestiavaloper1l2r0vxugpspk6zehtlv0y9gw9x2d7spfd5glp7 number_of_signatures=0
I[2023-12-03|03:34:59.426] 4SV                                          evm_address=0xC9aA59Bf68ff97fC67cDade3F20ed8220bF6762B valop_address=celestiavaloper1xzry8a3ss08tpwmfrg4u827rqt9juw320d00lx number_of_signatures=2
I[2023-12-03|03:34:59.426] Stakeflow                                    evm_address=0x3400CcE6D75E5977Bc8f929e3613A73837297944 valop_address=celestiavaloper1xle5xcnxxftlqwa4f5upc5n0kxwj6jrm4q6r0r number_of_signatures=2
I[2023-12-03|03:34:59.426] NodeStake                                    evm_address=0xeB73Ca18989B3156Ef25AEE52F0acD4E2Ef648E4 valop_address=celestiavaloper1etx55kw7tkmnjqz0k0mups4ewxlr324tpqxxjd number_of_signatures=2
I[2023-12-03|03:34:59.426] Imperator.co                                 evm_address=0x312bA6A47774F3904082D6fDbD72ef5b230B82A2 valop_address=celestiavaloper1xy46dfrhwneeqsyz6m7m6uh0tv3shq4zp5vpj8 number_of_signatures=0
I[2023-12-03|03:34:59.426] ContributionDAO                              evm_address=0x99fC13a5b46491D84494165FFaa540fFE7AB78D1 valop_address=celestiavaloper1f5crra7r5m9kd6saw077u76x0n7dyjkkzk0qup number_of_signatures=2
I[2023-12-03|03:34:59.426] Staked                                       evm_address=0x589Ae7CAA9ef61F0D6e3F0078968D77Da73B0F1e valop_address=celestiavaloper1tzdw0j4faaslp4hr7qrcj6xh0knnkrc7ug3edp number_of_signatures=0
I[2023-12-03|03:34:59.426] BlackBlocks                                  evm_address=0x9F8498EB284980Fe9c5Bb27cd3dAB8A0Fe5ed8b1 valop_address=celestiavaloper16rqus39n3e4868symf9ra9cpvlgtzyqth23gzy number_of_signatures=2
I[2023-12-03|03:34:59.426] KingSuper                                    evm_address=0x674c22Dc933C01465A32436F6464e6Ca797168Cb valop_address=celestiavaloper1vaxz9hyn8sq5vk3jgdhkge8xefuhz6xtnvy44x number_of_signatures=0
I[2023-12-03|03:34:59.426] Stakin                                       evm_address=0x7269D16A21D92d79E5849625dD1Dcd443d7392AE valop_address=celestiavaloper1wf5az63pmykhnevyjcja68wdgs7h8y4w565lha number_of_signatures=0
I[2023-12-03|03:34:59.426] Easy 2 Stake                                 evm_address=0x90D605752Ec6F308aD3FA1DaB4e578ce26632a1c valop_address=celestiavaloper1uf69uqke5cfmt4ga0c0cv7el9hvuj6xusn59r8 number_of_signatures=2
I[2023-12-03|03:34:59.426] UbikCapital                                  evm_address=0xEf5AE50f9d7D3CdB88b55225f722D342090332E9 valop_address=celestiavaloper1v5a42npqehg8r9fhjxaxp8adarty9melnsj9z7 number_of_signatures=2
I[2023-12-03|03:34:59.427] 🌐 KysenPool Celestia Test                    evm_address=0x723333c06a5C03c9701d57AA3f4a2547d59798F4 valop_address=celestiavaloper1wgen8sr2tspujuqa274r7j39gl2e0x85e48q6v number_of_signatures=0
I[2023-12-03|03:34:59.427] ANCLO                                        evm_address=0xF3C00568199baAA7F12dA048F1D0b60A22b92B7e valop_address=celestiavaloper170qq26qenw420ufd5py0r59kpg3tj2m7dqkpym number_of_signatures=0
I[2023-12-03|03:34:59.427] Nodes.Guru                                   evm_address=0x506dEa7bbc6fc7BCd04f44E52285b4F88B6C19F5 valop_address=celestiavaloper19urg9awjzwq8d40vwjdvv0yw9kgehscf0zx3gs number_of_signatures=2
I[2023-12-03|03:34:59.427] wavefive                                     evm_address=0x68Ee0DBa7DA396Fc9d8ce938ee0eFbB57a8cEf5A valop_address=celestiavaloper1gkvacjwejmgmql0up7ymu8gxlfucvu6u5zu937 number_of_signatures=2
I[2023-12-03|03:34:59.427] Simply Staking                               evm_address=0x000Ad6F3f24F3b1E0976622Fa22f1Db84468500C valop_address=celestiavaloper1qq9dduljfua3uztkvgh6ytcahpzxs5qvkq97l3 number_of_signatures=0
I[2023-12-03|03:34:59.427] cryptonodes.pro                              evm_address=0xE8dF771Be36Ee789dD6C505832B6c4826B455F51 valop_address=celestiavaloper1w8hktwz3fdxgfuxezlj3jseatfdttjr4pw0vkh number_of_signatures=2
I[2023-12-03|03:34:59.427] Synergy Nodes                                evm_address=0x3660019D926123595f8F5784Df3c81fBE73cB299 valop_address=celestiavaloper1xesqr8vjvy34jhu027zd70ypl0nnev5ejgmszq number_of_signatures=0
I[2023-12-03|03:34:59.427] StakingCabin                                 evm_address=0xb35857528487F7eAB6930563F145e3E78cF76f46 valop_address=celestiavaloper12dp3z5c8e47869ktxxggrkjzh67zl2w8rks96g number_of_signatures=2
I[2023-12-03|03:34:59.427] staker-space                                 evm_address=0x31540f08c6f13aBbf712b57f55C877F160fd3F6E valop_address=celestiavaloper1vudj6qgcstlwt8esdfcj3ssj00enewhj3jhsr4 number_of_signatures=2
I[2023-12-03|03:34:59.427] Anonstake                                    evm_address=0x03DD53aA8366f37f7Af647F463CAdea8dC2f6734 valop_address=celestiavaloper1c7e2pt8j78rnjps59zuvmmzswxe5uvl2k98ey3 number_of_signatures=2
I[2023-12-03|03:34:59.427] itrocket                                     evm_address=0x799625C5f47058A89867D7A026769ea6F6346f4f valop_address=celestiavaloper1n94ezezjz99knnpla7a6p8xftnlr23zacsaxht number_of_signatures=2
I[2023-12-03|03:34:59.427] Benni                                        evm_address=0x86995D7006a0Baa93898ed3665c2cfC51A22567d valop_address=celestiavaloper1xl003xjhah06qnsrseqvrz5gkxp96nflzzmedp number_of_signatures=0
I[2023-12-03|03:34:59.427] NakoTurk                                     evm_address=0x5b68e043EB468578D873F79370a7B100BB194c13 valop_address=celestiavaloper10jhckjxxymsufflglvypxscnmggetwh0dklfck number_of_signatures=2
I[2023-12-03|03:34:59.427]                                              evm_address=0x52Af26b80c01E6bf2BB64B20ac55648ea5dA3723 valop_address= number_of_signatures=0
I[2023-12-03|03:34:59.427] moonli.me                                    evm_address=0x6dd0D831E9Cb470113192d12907bfa19F5F77415 valop_address=celestiavaloper1yg6057eah240sxdrjzt8dl4emg2zvrvm4hldup number_of_signatures=2
I[2023-12-03|03:34:59.427] XPRV                                         evm_address=0x5469ea7904392A1b028305e583a4352eF3E3D120 valop_address=celestiavaloper1235757gy8y4pkq5rqhjc8fp49me785fqerkffs number_of_signatures=0
I[2023-12-03|03:34:59.427] Figment                                      evm_address=0xf9B9979Cf888d63387CB28562386F741E21C5Dfc valop_address=celestiavaloper1lfsagyl26mzc0wa9w0ujy6mhfefxylatz9ad3z number_of_signatures=2
I[2023-12-03|03:34:59.427] Stakecito                                    evm_address=0xF7B859736CB31B24E846865d7B5eaa9A134a969a valop_address=celestiavaloper19zl80606wn6hj575r20wxyeku7tet9p34ufpns number_of_signatures=2
I[2023-12-03|03:34:59.428] Crypto Plant                                 evm_address=0x3F80b45d70a0aE285458e833A2d644E4a110cB8C valop_address=celestiavaloper187qtghts5zhzs4zcaqe694jyujs3pjuv7nydgj number_of_signatures=0
I[2023-12-03|03:34:59.428] Alphabet                                     evm_address=0xFd662Bb8aEa2C35eFe9135749727C58e6218112e valop_address=celestiavaloper1davz40kat93t49ljrkmkl5uqhqq45e0tuj2s3m number_of_signatures=2
I[2023-12-03|03:34:59.428] Rumbanoid                                    evm_address=0x08fD774024E55bfCA5F5d2811077Ddd8F504de9e valop_address=celestiavaloper1a4mz9j3p6qva8a4c5mz2ljk8ww7jwemkp3252t number_of_signatures=2
I[2023-12-03|03:34:59.428] Iso_dayI                                     evm_address=0xCd2D30CaCeE0bD0D4429A5ca50285F34D5BFD643 valop_address=celestiavaloper1e5knpjkwuz7s63pf5h99q2zlxn2ml4jrz37lwe number_of_signatures=0
I[2023-12-03|03:34:59.428] Cosmos Spaces                                evm_address=0xAD920a4F40A1b1e933A977045a0F8a0fcF98734b valop_address=celestiavaloper14kfq5n6q5xc7jvafwuz95ru2pl8esu6tr3lelv number_of_signatures=0
I[2023-12-03|03:34:59.428] Avril14th                                    evm_address=0x4BA7Ed80Effde88a603c4cDBDC14fE4981801bA9 valop_address=celestiavaloper16w6vr4neaxtk779edzz23e0v6z66fgrt7y8wt0 number_of_signatures=0
I[2023-12-03|03:34:59.428] bg-1                                         evm_address=0xA80feACd103A5798166418e8C20637a71a03956E valop_address=celestiavaloper14q874ngs8ftes9nyrr5vyp3h5udq89tw93lvjy number_of_signatures=0
I[2023-12-03|03:34:59.428] Coinbase Cloud 1                             evm_address=0xF71ca0CF2d0Aca55F3D5acBBee051670b0B01248 valop_address=celestiavaloper104tmm72hye422h2tc3utxfqu5hkxefwwplqxut number_of_signatures=0
I[2023-12-03|03:34:59.428] TrustedPoint                                 evm_address=0x4f20E681c21878d7d43d3f81a87ef72f2A172f11 valop_address=celestiavaloper1fuswdqwzrpud04pa87q6slhh9u4pwtc3rzvhna number_of_signatures=0
I[2023-12-03|03:34:59.428] Gunter                                       evm_address=0x06EB845807E64910709F0bdb75C41d76A92c7915 valop_address=celestiavaloper1ufy9r82jzmyuk3n9ejlwgwvsxf20vcehx3ygfy number_of_signatures=2
I[2023-12-03|03:34:59.428] CrazyStaking                                 evm_address=0xCC78ee69D2AEB323d467A5Aa978b4930C8f82f3e valop_address=celestiavaloper1e3uwu6wj46ej84r85k4f0z6fxry0ste7lgantl number_of_signatures=0
I[2023-12-03|03:34:59.428] hipparcos                                    evm_address=0xE5030baC01c9a5be71A3603408C68026d4242057 valop_address=celestiavaloper1u5pshtqpexjmuudrvq6q335qym2zggzhyp5ee8 number_of_signatures=0
I[2023-12-03|03:34:59.428] KalpaTech                                    evm_address=0x312AB400df10a3F9749451A1DE7Ad08C9E1040c5 valop_address=celestiavaloper1xy4tgqxlzz3ljay52xsau7ks3j0pqsx9tktdqe number_of_signatures=0
I[2023-12-03|03:34:59.428] P-OPS Team                                   evm_address=0x67aCcf90FB08d79e8f67B48479d7eA424D94B64e valop_address=celestiavaloper1q3v5cugc8cdpud87u4zwy0a74uxkk6u4q4gx4p number_of_signatures=2
I[2023-12-03|03:34:59.428] Veam                                         evm_address=0x1a4FA32CC1b31920AD623236055480353eF13b1b valop_address=celestiavaloper157pdkj8nvuexdkgz9g338tmnfaz4u0eyghjzxg number_of_signatures=2
I[2023-12-03|03:34:59.428] Active Nodes                                 evm_address=0x8D475B8d237A77a75265befE4f32253E794A6eCE valop_address=celestiavaloper1pgprq60z9tfewajcxsg8t9gn98at08a4jw6qtq number_of_signatures=2
I[2023-12-03|03:34:59.428] kjnodes                                      evm_address=0x0fe244CcD11892232E390a7b7F37F68042952f94 valop_address=celestiavaloper13y5d6t28kumgmsr6jhmtj0s8p08yqvel70gyyp number_of_signatures=2
I[2023-12-03|03:34:59.428] DSRV                                         evm_address=0x1a7fC5dA39e38EdC3bB9B99Dc463650e5d66Ce9a valop_address=celestiavaloper1rflutk3euw8dcwaehxwugcm9pewkdn56xjlh26 number_of_signatures=0
I[2023-12-03|03:34:59.428] P2P.ORG                                      evm_address=0x6fDB87D802BBD2eA22e742680a7Cdf8BC89cc0Ca valop_address=celestiavaloper1dldc0kqzh0fw5gh8gf5q5lxl30yfesx2ek56mc number_of_signatures=0
I[2023-12-03|03:34:59.428] ChainodeTech                                 evm_address=0x805a47f6F9E53a8E8387B3aD817E0b3aC635F4Fc valop_address=celestiavaloper109nzhf6fvqvfan3tayzc8cywcsk6a5q45lmk5s number_of_signatures=2
I[2023-12-03|03:34:59.428] Blockpower Capital                           evm_address=0x649fE87EB9Afb124E7F7A896C72F45df2bF31503 valop_address=celestiavaloper162rcfau3ff29lh6juahlrp6xx5wh4xvhr5rx8s number_of_signatures=0
I[2023-12-03|03:34:59.429] YUTK                                         evm_address=0x882a092F17D3E583935f7D328Aa33f0C5F2254F1 valop_address=celestiavaloper1hu24jt4h5a62s3durjrclu0hn32pafajtq9j4u number_of_signatures=2
I[2023-12-03|03:34:59.429] 01node                                       evm_address=0x5397b0b4488412ffbe3d9598234002fB93c5127a valop_address=celestiavaloper12wtmpdzgssf0l03ajkvzxsqzlwfu2yn657e3dr number_of_signatures=0
I[2023-12-03|03:34:59.429] Brightlystake                                evm_address=0x6dc6034582aA4A94B1383bdCEdba3D762f5ac46b valop_address=celestiavaloper1u655tgul3su7s0u7kxyh6mdwcy5qn6xwl32s0d number_of_signatures=2
I[2023-12-03|03:34:59.429] Blockdaemon                                  evm_address=0xcF2e5Db58DB8D9Ece60d1B4e2667C3F84EE21516 valop_address=celestiavaloper1j7f2vwshnylrj3pklt30gesxywsuefkf622vf0 number_of_signatures=2
I[2023-12-03|03:34:59.429] BlockHunters 🎯                               evm_address=0xD92d278eFC7771b91706e1e857771217c4A34492 valop_address=celestiavaloper1mykj0rhuwacmj9cxu859wacjzlz2x3yjfajjju number_of_signatures=0
I[2023-12-03|03:34:59.429] Cumulo                                       evm_address=0x507800bE1b0D51D0BB72D3ae9fC167653b598a12 valop_address=celestiavaloper16yv2p64nzps0lqcealnumrsqc2rcszkd0uzlp8 number_of_signatures=2
I[2023-12-03|03:34:59.429] node101                                      evm_address=0x0138E049f836757F8a43e50fe9910e76D177C6fd valop_address=celestiavaloper1qyuwqj0cxe6hlzjru587nygwwmgh03ha9ve9ac number_of_signatures=0
I[2023-12-03|03:34:59.429] SilverSURF                                   evm_address=0x14dBEdb2Cb51bf57EB6705d24E8A488fa5DD0a45 valop_address=celestiavaloper1wnrvkxpzsxcf35tnr72rf97pazdgwcqert8t7t number_of_signatures=2
I[2023-12-03|03:34:59.429] Jav1xRisen                                   evm_address=0xD2494518a97168b9d8a407b530283d687613F322 valop_address=celestiavaloper1cyhkmeya2hdq0yw6amqr7drjwz5lwrpna8sjv3 number_of_signatures=2
I[2023-12-03|03:34:59.429] Validatus                                    evm_address=0x27aa15f7C8493A1627fD6944f30A4d29D05C404F valop_address=celestiavaloper1y74pta7gfyapvflad9z0xzjd98g9csz0k4z7a7 number_of_signatures=0
I[2023-12-03|03:34:59.429] Chorus One                                   evm_address=0xb4009C6Ab5a100754E2151F8b0AE8F7A48D68D7F valop_address=celestiavaloper1ksqfc6445yq82n3p28utpt500fyddrtlezx3pp number_of_signatures=0
I[2023-12-03|03:34:59.429] F5 Nodes                                     evm_address=0x726efcDBb724ADBc9FFEC67Fd628268EDc4d9C73 valop_address=celestiavaloper1z4ekxw76wtwczexfnjx8p9vcnt2pj7p6jrvwr0 number_of_signatures=2
I[2023-12-03|03:34:59.429] BitGo                                        evm_address=0xC05cA2443E63E2e6344053b8e46B4AEfE4EF8Dd7 valop_address=celestiavaloper1cpw2y3p7v03wvdzq2wuwg662aljwlrwhy08mkt number_of_signatures=0
I[2023-12-03|03:34:59.429] Rysiman                                      evm_address=0xe6af6C9BE0DeA45a52Ba836E8491a04c3ED35137 valop_address=celestiavaloper1awmke0zrufvl42kmmlnuxxqq6avg8397m22v4u number_of_signatures=0
I[2023-12-03|03:34:59.429] spidey                                       evm_address=0x2a96A3Dd96AA62DD1947C6b1E3e6b6BEB7ca6CED valop_address=celestiavaloper1qjshyuh77s7sz0l5kq4ft22pm0686qf36sx4cy number_of_signatures=2
I[2023-12-03|03:34:59.429] Stakely.io                                   evm_address=0x5Ae53764678970F6Cc1CA724deB37dbC144D2f28 valop_address=celestiavaloper1kxqzvmsa62v2xpd4ryzthgqp9lxa7qhw7qeu4g number_of_signatures=2
I[2023-12-03|03:34:59.429] melea                                        evm_address=0xfd778332c7B7726ef3B432e491f576A13f0E27Cd valop_address=celestiavaloper1l4mcxvk8kaexaua5xtjfratk5ylsuf7dg864ve number_of_signatures=0
I[2023-12-03|03:34:59.429] JeTrix                                       evm_address=0xBe903FC96265811e2D78F76eaFFc8B0273bA021f valop_address=celestiavaloper1t0289w0eq70h24dvp84g46awpzutdj65ltqa09 number_of_signatures=2
I[2023-12-03|03:34:59.429] done                       
```

And also supports json outputs.

## Checklist

<!-- 
Please complete the checklist to ensure that the PR is ready to be reviewed.

IMPORTANT:
PRs should be left in Draft until the below checklist is completed.
-->

- [ ] New and updated code has appropriate documentation
- [ ] New and updated code has new and/or updated testing
- [ ] Required CI checks are passing
- [ ] Visual proof for any user facing features like CLI or documentation updates
- [ ] Linked issues closed with keywords


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new command for querying orchestrator information in blobstream.
  - Added subcommands to query signers by specific nonce or within a range of nonces.

- **Enhancements**
  - Updated querying logic to handle specific nonces and nonce ranges.
  - Improved resource management and error handling in the start-up process.

- **Bug Fixes**
  - Adjusted the output structure for signature queries to enhance clarity and error reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->